### PR TITLE
Rename constants to index.js in constants

### DIFF
--- a/test/constants/index.js
+++ b/test/constants/index.js
@@ -28,7 +28,14 @@ import {
 	EPOCH_TIME_MILLISECONDS,
 	MAX_ADDRESS_NUMBER,
 	MAX_TRANSACTION_AMOUNT,
+	LIVE_PORT,
+	SSL_PORT,
+	TEST_PORT,
+	GET,
+	POST,
 	PUT,
+	MAINNET_NETHASH,
+	TESTNET_NETHASH,
 } from 'constants';
 
 describe('constants', () => {
@@ -92,7 +99,35 @@ describe('constants', () => {
 		return MAX_TRANSACTION_AMOUNT.should.be.a('string');
 	});
 
+	it('LIVE_PORT should be a string', () => {
+		return LIVE_PORT.should.be.a('string');
+	});
+
+	it('SSL_PORT should be a string', () => {
+		return SSL_PORT.should.be.a('string');
+	});
+
+	it('TEST_PORT should be a string', () => {
+		return TEST_PORT.should.be.a('string');
+	});
+
+	it('GET should be a string', () => {
+		return GET.should.be.a('string');
+	});
+
+	it('POST should be a string', () => {
+		return POST.should.be.a('string');
+	});
+
 	it('PUT should be a string', () => {
 		return PUT.should.be.a('string');
+	});
+
+	it('MAINNET_NETHASH should be a string', () => {
+		return MAINNET_NETHASH.should.be.a('string');
+	});
+
+	it('TESTNET_NETHASH should be a string', () => {
+		return TESTNET_NETHASH.should.be.a('string');
 	});
 });


### PR DESCRIPTION
### What was the problem?

`test/` folder was not reflecting `src/` folder on this file.
Some tests for constants were missing

### How did I fix it?

Rename `test/contstants/constants.js` to `test/constants/index.js`
Add missing tests

### Review checklist

* The PR solves #592
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
