### PR TITLE
Rename to lisk elements - Closes #567

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@
  *
  */
 pipeline {
-	agent { node { label 'lisk-js' } }
+	agent { node { label 'lisk-elements' } }
 	stages {
 		stage('Install dependencies') {
 			steps {
@@ -58,14 +58,14 @@ pipeline {
 	post {
 		success {
 			deleteDir()
-			githubNotify context: 'continuous-integration/jenkins/lisk-js', description: 'The build passed.', status: 'SUCCESS'
+			githubNotify context: 'continuous-integration/jenkins/lisk-elements', description: 'The build passed.', status: 'SUCCESS'
 		}
 		failure {
 			archiveArtifacts allowEmptyArchive: true, artifacts: 'cypress/screenshots/'
-			githubNotify context: 'continuous-integration/jenkins/lisk-js', description: 'The build failed.', status: 'FAILURE'
+			githubNotify context: 'continuous-integration/jenkins/lisk-elements', description: 'The build failed.', status: 'FAILURE'
 		}
 		aborted {
-			githubNotify context: 'continuous-integration/jenkins/lisk-js', description: 'The build was aborted.', status: 'ERROR'
+			githubNotify context: 'continuous-integration/jenkins/lisk-elements', description: 'The build was aborted.', status: 'ERROR'
 		}
 	}
 }

--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -1,5 +1,5 @@
 pipeline {
-       agent { node { label 'lisk-js' } }
+       agent { node { label 'lisk-elements' } }
        stages {
                stage('Cache dependencies') {
                        steps {

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-# <a href="http://liskhq.github.io/lisk-js/">Lisk-JS</a>
+# <a href="http://liskhq.github.io/lisk-elements/">lisk-elements</a>
 
-Lisk JS is a JavaScript library for [Lisk - the cryptocurrency and blockchain application platform](https://github.com/LiskHQ/lisk). It allows developers to create offline transactions and broadcast them onto the network. It also allows developers to interact with the core Lisk API, for retrieval of collections and single records of data located on the Lisk blockchain. Its main benefit is that it does not require a locally installed Lisk node, and instead utilizes the existing nodes on the network. It can be used from the client as a [browserify](http://browserify.org/) compiled module, or on the server as a standard Node.js module.
+Lisk Elements is a JavaScript library for [Lisk - the cryptocurrency and blockchain application platform](https://github.com/LiskHQ/lisk). It allows developers to create offline transactions and broadcast them onto the network. It also allows developers to interact with the core Lisk API, for retrieval of collections and single records of data located on the Lisk blockchain. Its main benefit is that it does not require a locally installed Lisk node, and instead utilizes the existing nodes on the network. It can be used from the client as a [browserify](http://browserify.org/) compiled module, or on the server as a standard Node.js module.
 
-[![Build Status](https://jenkins.lisk.io/buildStatus/icon?job=lisk-js/development)](https://jenkins.lisk.io/job/lisk-js/job/development/)
-[![Coverage Status](https://coveralls.io/repos/github/LiskHQ/lisk-js/badge.svg?branch=development)](https://coveralls.io/github/LiskHQ/lisk-js?branch=development)
+[![Build Status](https://jenkins.lisk.io/buildStatus/icon?job=lisk-elements/development)](https://jenkins.lisk.io/job/lisk-elements/job/development/)
+[![Coverage Status](https://coveralls.io/repos/github/LiskHQ/lisk-elements/badge.svg?branch=development)](https://coveralls.io/github/LiskHQ/lisk-elements?branch=development)
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](http://www.gnu.org/licenses/gpl-3.0)
 [![GitHub release](https://img.shields.io/badge/version-0.4.5-blue.svg)](#)
 
 ## Browser
 
 ```html
-<script src="./lisk-js.js"></script>
+<script src="./lisk-elements.js"></script>
 <script>
 	lisk.api().searchDelegateByUsername('oliver', function (response) {
 		console.log(response);
@@ -20,26 +20,26 @@ Lisk JS is a JavaScript library for [Lisk - the cryptocurrency and blockchain ap
 
 ## CDN
 
-https://gitcdn.xyz/repo/LiskHQ/lisk-js/browser/lisk-js.js<br/>
+https://gitcdn.xyz/repo/LiskHQ/lisk-elements/browser/lisk-elements.js<br/>
 ```html
-<script src="https://gitcdn.xyz/repo/LiskHQ/lisk-js/browser/lisk-js.js"></script>
+<script src="https://gitcdn.xyz/repo/LiskHQ/lisk-elements/browser/lisk-elements.js"></script>
 ```
 Or minified:
-https://gitcdn.xyz/repo/LiskHQ/lisk-js/browser/lisk-js.min.js<br/>
+https://gitcdn.xyz/repo/LiskHQ/lisk-elements/browser/lisk-elements.min.js<br/>
 ```html
-<script src="https://gitcdn.xyz/repo/LiskHQ/lisk-js/browser/lisk-js.min.js"></script>
+<script src="https://gitcdn.xyz/repo/LiskHQ/lisk-elements/browser/lisk-elements.min.js"></script>
 ```
 
 ## Server
 
 ## Install
 ```
-$ npm install lisk-js --save
+$ npm install lisk-elements --save
 ```
 
 To learn more about the API or to experiment with some data, please go to the github page:
 
-http://liskhq.github.io/lisk-js/
+http://liskhq.github.io/lisk-elements/
 
 ## Tests
 
@@ -51,7 +51,7 @@ Tests written using mocha + schedule.js.
 
 ## Documentation
 
-- [Install](https://docs.lisk.io/docs/lisk-js-installation)
+- [Install](https://docs.lisk.io/docs/lisk-elements-installation)
 - [API](https://docs.lisk.io/docs/api-functions)
 	- [Settings](https://docs.lisk.io/docs/api)
 	- [API Functions](https://docs.lisk.io/docs/api-functions)
@@ -80,7 +80,7 @@ This program is free software: you can redistribute it and/or modify it under th
 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
-You should have received a copy of the [GNU General Public License](https://github.com/LiskHQ/lisk-js/tree/master/LICENSE) along with this program.  If not, see <http://www.gnu.org/licenses/>.
+You should have received a copy of the [GNU General Public License](https://github.com/LiskHQ/lisk-elements/tree/master/LICENSE) along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 ***
 

--- a/bin/prestart.sh
+++ b/bin/prestart.sh
@@ -1,4 +1,4 @@
-read -r -p $'\e[96mDo you want to build LiskJS first? [y/N]\e[0m ' should_build
+read -r -p $'\e[96mDo you want to build Lisk Elements first? [y/N]\e[0m ' should_build
 if [[ $should_build =~ ^[Yy]$ ]]
 then
 	npm run build

--- a/bin/publish_browser.sh
+++ b/bin/publish_browser.sh
@@ -7,7 +7,7 @@ VERSION=$(node -p -e "require('./package.json').version")
 {
 	git checkout -b $BRANCHNAME_TEMP
 	mkdir dist-browser-temp
-	cp dist-browser/lisk-js.* $DIRNAME_TEMP && \
+	cp dist-browser/lisk-elements.* $DIRNAME_TEMP && \
 	cp dist-browser/README.md $DIRNAME_TEMP && \
 	git add dist-browser-temp && \
 	git commit -m "Publish browser version $VERSION" --no-verify && \

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,1 +1,1 @@
-node -i -e "global.LiskJS = require('./dist-node').default; console.log('\\x1b[34m', 'The global \`LiskJS\` was initialised', '\\x1b[0m')"
+node -i -e "global.LiskElements = require('./dist-node').default; console.log('\\x1b[34m', 'The global \`LiskElements\` was initialised', '\\x1b[0m')"

--- a/dist-browser/README.md
+++ b/dist-browser/README.md
@@ -1,6 +1,6 @@
-# lisk-js browser distribution
+# lisk-elements browser distribution
 
-This branch contains the built lisk-js distribution files, ready for use in the browser. There is a
+This branch contains the built lisk-elements distribution files, ready for use in the browser. There is a
 full build and a minified build (which is the one you want to use in most cases).
 
 ## Updating these files

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to Lisk-JS
+# Contributing to Lisk-Elements
 
 First off, thanks for taking the time to contribute! :raised_hands:
 
-The following is a set of guidelines for contributing to Lisk-JS, which are hosted in the [LiskHQ Organization](https://github.com/LiskHQ) on GitHub. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+The following is a set of guidelines for contributing to Lisk Elements, which are hosted in the [LiskHQ Organization](https://github.com/LiskHQ) on GitHub. These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
 
 #### Table Of Contents
 
@@ -21,7 +21,7 @@ The following is a set of guidelines for contributing to Lisk-JS, which are host
 
 ## Code of Conduct
 
-This project and everyone participating in it is governed by the [Lisk-JS Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [info@lisk.io](mailto:info@lisk.io).
+This project and everyone participating in it is governed by the [Lisk Elements Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [info@lisk.io](mailto:info@lisk.io).
 
 ## Project License
 
@@ -63,7 +63,7 @@ In case you've never submitted a pull request (PR) via GitHub before, please rea
 
 ### Reporting Bugs
 
-This section guides you through submitting a bug report for Lisk-JS. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
+This section guides you through submitting a bug report for Lisk Elements. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behavior :computer: :computer:, and find related reports :mag_right:.
 
 Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](ISSUE_TEMPLATE.md), the information it asks for helps us resolve issues faster.
 
@@ -82,7 +82,7 @@ Bugs are tracked as [GitHub issues](https://guides.github.com/features/issues/).
 Explain the problem and include additional details to help maintainers reproduce the problem:
 
 * **Use a clear and descriptive title** for the issue to identify the problem.
-* **Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you started Lisk-JS, e.g. with Node.js or in the Browser (which one? which version?), or how you started Lisk-JS otherwise. When listing steps, **don't just say what you did, but explain how you did it**. For example, if you have used an API model provide the configuration you have chosen and the functions you have executed. **Make sure to erase sensitive information from the configuration or details you are passing - NEVER SHARE YOUR SECRET PASSPHRASES OR PRIVATE KEYS**.
+* **Describe the exact steps which reproduce the problem** in as many details as possible. For example, start by explaining how you started Lisk Elements, e.g. with Node.js or in the Browser (which one? which version?), or how you started Lisk Elements otherwise. When listing steps, **don't just say what you did, but explain how you did it**. For example, if you have used an API model provide the configuration you have chosen and the functions you have executed. **Make sure to erase sensitive information from the configuration or details you are passing - NEVER SHARE YOUR SECRET PASSPHRASES OR PRIVATE KEYS**.
 * **Provide specific examples to demonstrate the steps**. Include links to files or GitHub projects, or copy/pasteable snippets, which you use in those examples. If you're providing snippets in the issue, use [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 * **Describe the behavior you observed after following the steps** and point out what exactly is the problem with that behavior.
 * **Explain which behavior you expected to see instead and why.**
@@ -91,13 +91,13 @@ Explain the problem and include additional details to help maintainers reproduce
 
 Provide more context by answering these questions:
 
-* **Did the problem start happening recently** (e.g. after updating to a new version of Lisk-JS, Lisk or any other repository) or was this always a problem?
-* If the problem started happening recently, **can you reproduce the problem in an older version of Lisk-JS?** What's the most recent version in which the problem doesn't happen? You can download older versions of Lisk-JS from [the releases page](https://github.com/LiskHQ/lisk-js/releases).
+* **Did the problem start happening recently** (e.g. after updating to a new version of Lisk Elements, Lisk or any other repository) or was this always a problem?
+* If the problem started happening recently, **can you reproduce the problem in an older version of Lisk Elements?** What's the most recent version in which the problem doesn't happen? You can download older versions of Lisk Elements from [the releases page](https://github.com/LiskHQ/lisk-elements/releases).
 * **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for Lisk-JS, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+This section guides you through submitting an enhancement suggestion for Lisk Elements, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
  When you are creating an enhancement suggestion, please include as many details as possible. Fill in [the template](ISSUE_TEMPLATE.md), including the steps that you imagine you would take if the feature you're requesting existed.
 
@@ -109,9 +109,9 @@ Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com
 * **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
 * **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 * **Describe the current behavior** and **explain which behavior you expected to see instead** and why.
-* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of Lisk-JS which the suggestion is related to. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
-* **Explain why this enhancement would be useful** to most Lisk and Lisk-JS users.
-* **Specify which version of Lisk and Lisk-JS you're using.**
+* **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of Lisk Elements which the suggestion is related to. You can use [this tool](http://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+* **Explain why this enhancement would be useful** to most Lisk and Lisk Elements users.
+* **Specify which version of Lisk and Lisk Elements you're using.**
 * **Specify the name and version of the OS you're using.**
 
 ## Styleguides

--- a/docs/ISSUE_TEMPLATE.md
+++ b/docs/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
-Have you read Lisk-JS's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: [Lisk-JS Code of Conduct](CODE_OF_CONDUCT.md)
+Have you read Lisk Elements Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: [Lisk Elements Code of Conduct](CODE_OF_CONDUCT.md)
 
 ### Description
 
@@ -19,7 +19,7 @@ Have you read Lisk-JS's Code of Conduct? By filing an Issue, you are expected to
 ### Versions
 
 Please provide the version you are working with. Please include the OS and what version of the OS you're running.
-Also please tell us whether you are using Lisk-JS in a browser (which one? which version?) or in Node.js.
+Also please tell us whether you are using Lisk Elements in a browser (which one? which version?) or in Node.js.
 
 ### Additional Information
 

--- a/index.html
+++ b/index.html
@@ -5,10 +5,10 @@
     <title>Title</title>
 </head>
 <body>
-Open the console to get started with `lisk-js`.
+Open the console to get started with `lisk-elements`.
 <div id="output"></div>
 
-<script src="dist-browser/lisk-js.min.js"></script>
+<script src="dist-browser/lisk-elements.min.js"></script>
 
 </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-	"name": "lisk-js",
-	"version": "0.4.5",
+	"name": "lisk-elements",
+	"version": "1.0.0",
 	"lockfileVersion": 1,
 	"dependencies": {
 		"@browserify/acorn5-object-spread": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-	"name": "lisk-js",
-	"version": "0.4.5",
+	"name": "lisk-elements",
+	"version": "1.0.0",
 	"description": "JavaScript library for sending Lisk transactions from the client or server",
 	"author": "Lisk Foundation <admin@lisk.io>, lightcurve GmbH <admin@lightcurve.io>",
 	"license": "GPL-3.0",
@@ -11,13 +11,13 @@
 		"javascript",
 		"library"
 	],
-	"homepage": "https://github.com/LiskHQ/lisk-js#readme",
+	"homepage": "https://github.com/LiskHQ/lisk-elements#readme",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/LiskHQ/lisk-js.git"
+		"url": "git+https://github.com/LiskHQ/lisk-elements.git"
 	},
 	"bugs": {
-		"url": "https://github.com/LiskHQ/lisk-js/issues"
+		"url": "https://github.com/LiskHQ/lisk-elements/issues"
 	},
 	"engines": {
 		"node": ">=6.3 <=9.5",
@@ -32,9 +32,9 @@
 		"lint:fix": "npm run lint -- --fix",
 		"babel": "babel src -d dist-node",
 		"babel:browsertest": "babel src -d ./browsertest/src && BABEL_ENV=browsertest babel test --ignore test/transactions/dapp.js -d ./browsertest/test",
-		"browserify": "browserify ./dist-node/index.js -o ./dist-browser/lisk-js.js -s lisk -t rewireify",
+		"browserify": "browserify ./dist-node/index.js -o ./dist-browser/lisk-elements.js -s lisk -t rewireify",
 		"browserify:browsertest": "browserify ./browsertest/test/*.js ./browsertest/test/**/*.js -o ./browsertest/browsertest.js -s lisk -t rewireify",
-		"uglify": "uglifyjs -nm -o ./dist-browser/lisk-js.min.js ./dist-browser/lisk-js.js",
+		"uglify": "uglifyjs -nm -o ./dist-browser/lisk-elements.min.js ./dist-browser/lisk-elements.js",
 		"uglify:browsertest": "uglifyjs -o ./browsertest/browsertest.min.js ./browsertest/browsertest.js",
 		"serve:browsertest": "http-server browsertest",
 		"test": "NODE_ENV=test nyc mocha test",
@@ -55,7 +55,7 @@
 		"postbuild:browsertest": "rm -r browsertest/src browsertest/test",
 		"prebuild:node": "rm -r dist-node/* || mkdir dist-node | echo",
 		"build:node": "npm run babel",
-		"prebuild:browser": "rm ./dist-browser/lisk-js.js ./dist-browser/lisk-js.min.js | echo",
+		"prebuild:browser": "rm ./dist-browser/lisk-elements.js ./dist-browser/lisk-elements.min.js | echo",
 		"build:browser": "npm run babel && npm run browserify && npm run uglify",
 		"prebuild": "npm run prebuild:node && npm run prebuild:browser",
 		"build": "npm run babel && npm run browserify && npm run uglify",

--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -40,7 +40,7 @@ const defaultOptions = {
 
 const commonHeaders = {
 	'Content-Type': 'application/json',
-	os: 'lisk-js-api',
+	os: 'lisk-elements-api',
 };
 
 const getHeaders = (nethash, version, minVersion) =>

--- a/test/api_client/api_client.js
+++ b/test/api_client/api_client.js
@@ -33,7 +33,7 @@ describe('APIClient module', () => {
 	const defaultHeaders = {
 		'Content-Type': 'application/json',
 		nethash: mainnetHash,
-		os: 'lisk-js-api',
+		os: 'lisk-elements-api',
 		version: '1.0.0',
 		minVersion: '>=1.0.0',
 	};
@@ -41,7 +41,7 @@ describe('APIClient module', () => {
 	const customHeaders = {
 		'Content-Type': 'application/json',
 		nethash: testnetHash,
-		os: 'lisk-js-api',
+		os: 'lisk-elements-api',
 		version: '0.5.0',
 		minVersion: '>=0.1.0',
 	};

--- a/test/api_client/api_resource.js
+++ b/test/api_client/api_resource.js
@@ -25,7 +25,7 @@ describe('API resource module', () => {
 	const defaultHeaders = {
 		'Content-Type': 'application/json',
 		nethash: 'mainnetHash',
-		os: 'lisk-js-api',
+		os: 'lisk-elements-api',
 		version: '1.0.0',
 		minVersion: '>=0.5.0',
 		port: '443',

--- a/test/cryptography/encrypt.js
+++ b/test/cryptography/encrypt.js
@@ -204,7 +204,7 @@ describe('encrypt', () => {
 					.and.be.hexString.and.have.length(32);
 			});
 
-			it('should output the current version of LiskJS', () => {
+			it('should output the current version of Lisk Elements', () => {
 				return expect(cipher)
 					.to.have.property('version')
 					.which.is.equal(version);


### PR DESCRIPTION
### What was the problem?

Lisk-JS is going to be renamed to Lisk Elements

### How did I fix it?

Replace Lisk-JS with Lisk Elements

### How to test it?

`npm t`

### Review checklist

* The PR solves #567
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
