### PR TITLE
Add browser field to package.json - Closes #681

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel": "babel src -d dist-node",
     "babel:browsertest": "babel src -d ./browsertest/src && BABEL_ENV=browsertest babel test --ignore test/transactions/dapp.js -d ./browsertest/test",
     "browserify": "browserify ./dist-node/index.js -o ./dist-browser/lisk-elements.js -s lisk --node",
-    "browserify:browsertest": "browserify ./browsertest/test/*.js ./browsertest/test/**/*.js -o ./browsertest/browsertest.js -s lisk -t rewireify",
+    "browserify:browsertest": "browserify ./browsertest/test/*.js ./browsertest/test/**/*.js -o ./browsertest/browsertest.js -s lisk",
     "uglify": "uglifyjs -nm -o ./dist-browser/lisk-elements.min.js ./dist-browser/lisk-elements.js",
     "uglify:browsertest": "uglifyjs -o ./browsertest/browsertest.min.js ./browsertest/browsertest.js",
     "serve:browsertest": "http-server browsertest",
@@ -96,7 +96,6 @@
     "mocha": "=4.0.1",
     "nyc": "=11.3.0",
     "prettier": "=1.8.2",
-    "rewireify": "=0.2.5",
     "sinon": "=4.1.2",
     "sinon-chai": "=2.14.0",
     "uglify-es": "=3.3.9"

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node": ">=6.3 <=9.5",
     "npm": ">=3 <=5"
   },
+  "browser": "dist-browser/lisk-elements.min.js",
   "main": "dist-node/index.js",
   "scripts": {
     "prestart": "./bin/prestart.sh",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint:fix": "npm run lint -- --fix",
     "babel": "babel src -d dist-node",
     "babel:browsertest": "babel src -d ./browsertest/src && BABEL_ENV=browsertest babel test --ignore test/transactions/dapp.js -d ./browsertest/test",
-    "browserify": "browserify ./dist-node/index.js -o ./dist-browser/lisk-elements.js -s lisk -t rewireify",
+    "browserify": "browserify ./dist-node/index.js -o ./dist-browser/lisk-elements.js -s lisk --node",
     "browserify:browsertest": "browserify ./browsertest/test/*.js ./browsertest/test/**/*.js -o ./browsertest/browsertest.js -s lisk -t rewireify",
     "uglify": "uglifyjs -nm -o ./dist-browser/lisk-elements.min.js ./dist-browser/lisk-elements.js",
     "uglify:browsertest": "uglifyjs -o ./browsertest/browsertest.min.js ./browsertest/browsertest.js",


### PR DESCRIPTION
### What was the problem?
We have a distribution for browsers, but entry point wasn't defined in package.json

### How did I fix it?
I added browser field in `package.json` and set the value to `dist-browser/lisk-elements.min.js`.

### How to test it?

### Review checklist

* The PR solves #681 and solves #689 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
  - add browser field to package.json
* Documentation has been added/updated
