### PR TITLE
Disable user-agent header when client options were not provided - Closes #696

### DIFF
--- a/src/api_client/api_client.js
+++ b/src/api_client/api_client.js
@@ -38,9 +38,13 @@ const commonHeaders = {
 	'Content-Type': 'application/json',
 };
 
-const getUserAgent = (
-	{ name = '????', version = '????', engine = '????' } = {},
-) => {
+const getUserAgent = clientOptions => {
+	if (!clientOptions) {
+		return {};
+	}
+
+	const { name = '????', version = '????', engine = '????' } = clientOptions;
+
 	const liskElementsInformation =
 		'LiskElements/1.0 (+https://github.com/LiskHQ/lisk-elements)';
 	const locale =
@@ -51,9 +55,12 @@ const getUserAgent = (
 	const systemInformation = `${os.platform()} ${os.release()}; ${os.arch()}${
 		locale ? `; ${locale}` : ''
 	}`;
-	return `${name}/${version} (${engine}) ${liskElementsInformation} ${
-		systemInformation
-	}`;
+
+	return {
+		'User-Agent': `${name}/${version} (${engine}) ${liskElementsInformation} ${
+			systemInformation
+		}`,
+	};
 };
 
 export default class APIClient {
@@ -107,9 +114,7 @@ export default class APIClient {
 			{},
 			commonHeaders,
 			options.nethash ? { nethash: options.nethash } : {},
-			{
-				'User-Agent': getUserAgent(options.client),
-			},
+			getUserAgent(options.client),
 		);
 
 		this.nodes = nodes;

--- a/test/api_client/api_client.js
+++ b/test/api_client/api_client.js
@@ -219,7 +219,7 @@ describe('APIClient module', () => {
 					version: customHeaders.version,
 					nethash: testnetHash,
 				});
-				return expect(apiClient.headers).to.not.have.property('client');
+				return expect(apiClient.headers).to.not.have.property('User-Agent');
 			});
 		});
 

--- a/test/api_client/api_client.js
+++ b/test/api_client/api_client.js
@@ -42,14 +42,13 @@ describe('APIClient module', () => {
 	const baseUserAgent = `LiskElements/1.0 (+https://github.com/LiskHQ/lisk-elements) ${
 		platformInfo
 	}`;
-	const defaultUserAgent = `????/???? (????) ${baseUserAgent}`;
+
 	const customUserAgent = `LiskHub/5.0 (+https://github.com/LiskHQ/lisk-hub) ${
 		baseUserAgent
 	}`;
 	const defaultHeaders = {
 		Accept: 'application/json',
 		'Content-Type': 'application/json',
-		'User-Agent': defaultUserAgent,
 	};
 
 	const customHeaders = {
@@ -213,6 +212,14 @@ describe('APIClient module', () => {
 				return expect(apiClient)
 					.to.have.property('headers')
 					.and.eql(customHeaders);
+			});
+
+			it('should not set User-Agent header when client options were not given', () => {
+				apiClient = new APIClient(defaultNodes, {
+					version: customHeaders.version,
+					nethash: testnetHash,
+				});
+				return expect(apiClient.headers).to.not.have.property('client');
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?
lisk-elements is throwing `Refused to set unsafe header “User-Agent”`warning when it's used in browsers.

### How did I fix it?
I updated getUserAgent function to return empty object when clientOptions were not provided.

### How to test it?

### Review checklist
* The PR solves #696 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the
	[commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
