### PR TITLE
Add select function to p2p connection - Closes#931

### DIFF
--- a/packages/lisk-p2p/src/peer_selection.ts
+++ b/packages/lisk-p2p/src/peer_selection.ts
@@ -117,3 +117,5 @@ export const selectPeers = (
 
 	return peerList;
 };
+
+export const selectForConnection = (peers: ReadonlyArray<Peer>) => peers;

--- a/packages/lisk-p2p/test/unit/peer_selection.ts
+++ b/packages/lisk-p2p/test/unit/peer_selection.ts
@@ -14,7 +14,11 @@
  */
 import { expect } from 'chai';
 import { initializePeerList } from '../utils/peers';
-import { PeerOptions, selectPeers } from '../../src/peer_selection';
+import {
+	PeerOptions,
+	selectForConnection,
+	selectPeers,
+} from '../../src/peer_selection';
 
 describe('peer selector', () => {
 	describe('#selectPeer', () => {
@@ -104,6 +108,20 @@ describe('peer selector', () => {
 				return expect(selectPeers(lowHeightPeers, selectionParams, 2))
 					.and.be.an('array')
 					.and.of.length(0);
+			});
+		});
+	});
+
+	describe('#selectForConnection', () => {
+		const peerList = initializePeerList();
+		const numberOfPeers = peerList.length;
+
+		describe('get all the peers for selection', () => {
+			it('should return all the peers given as argument for connection', () => {
+				return expect(selectForConnection(peerList))
+					.be.an('array')
+					.and.is.eql(peerList)
+					.of.length(numberOfPeers);
 			});
 		});
 	});


### PR DESCRIPTION
### Description 

Implement selectForConnection to make a selection and connect with peers. This implementation covers phase 1 which simply returns all the known peers.

### Review checklist

* The PR resolves #931
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
