### PR TITLE
Implement P2P.getNetworkStatus() functionality - Closes #985 and #897, addresses #896 and #953

### DIFF
--- a/packages/lisk-p2p/package.json
+++ b/packages/lisk-p2p/package.json
@@ -29,6 +29,7 @@
 		"lint": "tslint --format verbose --project .",
 		"lint:fix": "npm run lint -- --fix",
 		"test": "TS_NODE_PROJECT=./test/tsconfig.json nyc mocha test/{,/**/}/*.ts",
+		"test:integration": "TS_NODE_PROJECT=./test/tsconfig.json nyc mocha test/integration/*.ts",
 		"test:watch": "npm test -- --watch",
 		"test:watch:min": "npm run test:watch -- --reporter=min",
 		"test:node": "npm run build:check",

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -22,10 +22,10 @@ import { attach, SCServer, SCServerSocket } from 'socketcluster-server';
 import { Peer, PeerInfo } from './peer';
 
 import {
-	// TODO ASAP: NetworkStatus,
 	P2PConfig,
 	P2PMessagePacket,
-	P2PNodeStatus,
+	P2PNetworkStatus,
+	P2PNodeInfo,
 	P2PPenalty,
 	P2PRequestPacket,
 	P2PResponsePacket,
@@ -49,22 +49,25 @@ const BASE_10_RADIX = 10;
 
 export class P2P extends EventEmitter {
 	private readonly _config: P2PConfig;
-	private readonly _peerPool: PeerPool;
 	private readonly _httpServer: Server;
-	private readonly _scServer: SCServerUpdated; // Until we get comeplete definition for SCServer
+	private _isActive: boolean;
 	private readonly _newPeers: Set<PeerInfo>;
-	// TODO ASAP: private readonly _triedPeers: Set<PeerInfo>;
-	private _nodeStatus: P2PNodeStatus;
+
+	// TODO ASAP: private readonly _triedPeers: Set<PeerConfig>;
+	private _nodeInfo: P2PNodeInfo;
+	private readonly _peerPool: PeerPool;
+	private readonly _scServer: SCServerUpdated;
 
 	public constructor(config: P2PConfig) {
 		super();
 		this._config = config;
-		this._nodeStatus = {
+		this._nodeInfo = {
 			wsPort: config.wsPort,
 			os: platform(),
 			version: config.version,
 			height: 0,
 		};
+		this._isActive = false;
 		this._newPeers = new Set();
 		// TODO ASAP: this._triedPeers = new Set();
 
@@ -73,16 +76,43 @@ export class P2P extends EventEmitter {
 		this._scServer = attach(this._httpServer) as SCServerUpdated;
 	}
 
+	public get isActive(): boolean {
+		return this._isActive;
+	}
+
+	public get nodeInfo(): P2PNodeInfo {
+		return this._nodeInfo;
+	}
+
+	/**
+	 * This is not a declared as a setter because this method will need
+	 * invoke an async RPC on Peers to give them our new node status.
+	 */
+	public applyNodeInfo(nodeInfo: P2PNodeInfo): void {
+		this._nodeInfo = nodeInfo;
+		const peerList = this._peerPool.getAllPeers();
+		peerList.forEach(peer => {
+			peer.applyNodeInfo(nodeInfo);
+		});
+	}
+
 	/* tslint:disable:next-line: prefer-function-over-method */
 	public applyPenalty(penalty: P2PPenalty): void {
 		penalty;
 	}
 
-	// TODO ASAP: public getNetworkStatus(): NetworkStatus {};
+	public getNetworkStatus(): P2PNetworkStatus {
+		// TODO ASAP: Add additional properties.
+		return {
+			peers: this._peerPool.getAllPeerInfos(),
+		};
+	}
+
 	/* tslint:disable:next-line: prefer-function-over-method */
 	public async request<T>(
 		packet: P2PRequestPacket<T>,
 	): Promise<P2PResponsePacket> {
+		// TODO ASAP
 		return Promise.resolve({ data: packet });
 	}
 
@@ -90,19 +120,6 @@ export class P2P extends EventEmitter {
 	public send<T>(message: P2PMessagePacket<T>): void {
 		message;
 		// TODO ASAP
-	}
-
-	public get nodeStatus(): P2PNodeStatus {
-		return this._nodeStatus;
-	}
-
-	/**
-	 * This is not a declared as a setter because this method will need
-	 * invoke an async RPC on Peers to give them our new node status.
-	 */
-	public applyNodeStatus(value: P2PNodeStatus): void {
-		this._nodeStatus = value;
-		// TODO ASAP: Pass to PeerPool -> connected Peer objects
 	}
 
 	private async _startPeerServer(): Promise<void> {
@@ -126,17 +143,14 @@ export class P2P extends EventEmitter {
 					const peerId = Peer.constructPeerId(socket.remoteAddress, wsPort);
 					const existingPeer = this._peerPool.getPeer(peerId);
 					if (existingPeer === undefined) {
-						const peer = new Peer(
-							{
-								ipAddress: socket.remoteAddress,
-								os: queryObject.os,
-								version: queryObject.version,
-								wsPort,
-								nodeStatus: this._nodeStatus,
-								height: queryObject.height ? +queryObject.height : 0,
-							},
-							socket,
-						);
+						const peer = new Peer({
+							inboundSocket: socket,
+							ipAddress: socket.remoteAddress,
+							os: queryObject.os,
+							version: queryObject.version,
+							wsPort,
+						});
+						peer.applyNodeInfo(this._nodeInfo);
 						this._peerPool.addPeer(peer);
 						super.emit(EVENT_NEW_INBOUND_PEER, peer);
 						super.emit(EVENT_NEW_PEER, peer);
@@ -152,6 +166,7 @@ export class P2P extends EventEmitter {
 
 		return new Promise<void>(resolve => {
 			this._scServer.once('ready', () => {
+				this._isActive = true;
 				resolve();
 			});
 		});
@@ -161,48 +176,46 @@ export class P2P extends EventEmitter {
 		// TODO ASAP: Test this and check for potential failure scenarios.
 		return new Promise<void>(resolve => {
 			this._scServer.close(() => {
+				this._isActive = false;
 				resolve();
 			});
 		});
 	}
 
+	// TODO ASAP: This should be refactored to use the discovery function.
 	private async _loadListOfPeerListsFromSeeds(
 		seedList: ReadonlyArray<PeerInfo>,
 	): Promise<ReadonlyArray<ReadonlyArray<Peer>>> {
 		return Promise.all(
-			seedList.map(async (seedPeer: PeerInfo) => {
-				const peer = new Peer({
-					ipAddress: seedPeer.ipAddress,
-					wsPort: seedPeer.wsPort,
-					nodeStatus: this._nodeStatus,
-					height: seedPeer.height,
-					os: seedPeer.os,
-					version: seedPeer.version,
-				});
-				this._newPeers.add(peer.peerInfo);
+			seedList.map(async (seedPeerInfo: PeerInfo) => {
+				const seedPeer = new Peer(seedPeerInfo);
+				seedPeer.applyNodeInfo(this._nodeInfo);
+				this._newPeers.add(seedPeer.peerInfo);
 				/**
-				 * TODO LATER: For the LIP phase, we shouldn't add the seed peers to our
+				 * TODO later: For the LIP phase, we shouldn't add the seed peers to our
 				 * _peerPool and we should disconnect from them as soon as we've loaded their peer lists.
 				 */
-				this._peerPool.addPeer(peer);
-				// TODO LATER: For the LIP phase, the 'list' request will need to be renamed.
-				const seedNodePeerListResponse = await peer.request<void>({
+				this._peerPool.addPeer(seedPeer);
+				// TODO later: For the LIP phase, the 'list' request will need to be renamed.
+				const seedNodePeerListResponse = await seedPeer.request<void>({
 					procedure: 'list',
 				});
 				const peerListResponse = seedNodePeerListResponse.data as ProtocolPeerList;
+				
 				// TODO ASAP: Validate the response before returning. Check that seedNodePeerListResponse.data.peers exists.
 
-				return peerListResponse.peers.map(
-					(peerObject: ProtocolPeerInfo) =>
-						new Peer({
-							ipAddress: peerObject.ip,
-							wsPort: peerObject.wsPort, // TODO ASAP: Add more properties
-							nodeStatus: this._nodeStatus,
-							height: seedPeer.height,
-							os: seedPeer.os,
-							version: seedPeer.version,
-						}),
-				);
+				return peerListResponse.peers.map((peerInfo: ProtocolPeerInfo) => {
+					const peer = new Peer({
+						ipAddress: peerInfo.ip,
+						wsPort: peerInfo.wsPort, // TODO ASAP: Add more properties
+						height: peerInfo.height,
+						os: peerInfo.os,
+						version: peerInfo.version,
+					});
+					peer.applyNodeInfo(this._nodeInfo);
+
+					return peer;
+				});
 			}),
 		);
 	}

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -52,8 +52,8 @@ export class P2P extends EventEmitter {
 	private readonly _httpServer: Server;
 	private _isActive: boolean;
 	private readonly _newPeers: Set<PeerInfo>;
+	private readonly _triedPeers: Set<PeerInfo>;
 
-	// TODO ASAP: private readonly _triedPeers: Set<PeerInfo>;
 	private _nodeInfo: P2PNodeInfo;
 	private readonly _peerPool: PeerPool;
 	private readonly _scServer: SCServerUpdated;
@@ -69,7 +69,7 @@ export class P2P extends EventEmitter {
 		};
 		this._isActive = false;
 		this._newPeers = new Set();
-		// TODO ASAP: this._triedPeers = new Set();
+		this._triedPeers = new Set();
 
 		this._peerPool = new PeerPool();
 		this._httpServer = http.createServer();
@@ -102,10 +102,14 @@ export class P2P extends EventEmitter {
 	}
 
 	public getNetworkStatus(): P2PNetworkStatus {
-		// TODO ASAP: Add additional properties such as _triedPeers.
+		const newPeers = [...this._newPeers.values()];
+		const triedPeers = [...this._triedPeers.values()];
+		const availablePeers = newPeers.concat(triedPeers);
 		return {
-			newPeers: [...this._newPeers.values()],
-			activePeers: this._peerPool.getAllPeerInfos(),
+			newPeers,
+			triedPeers,
+			availablePeers,
+			connectedPeers: this._peerPool.getAllPeerInfos(),
 		};
 	}
 

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -104,11 +104,9 @@ export class P2P extends EventEmitter {
 	public getNetworkStatus(): P2PNetworkStatus {
 		const newPeers = [...this._newPeers.values()];
 		const triedPeers = [...this._triedPeers.values()];
-		const availablePeers = newPeers.concat(triedPeers);
 		return {
 			newPeers,
 			triedPeers,
-			availablePeers,
 			connectedPeers: this._peerPool.getAllPeerInfos(),
 		};
 	}

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -144,13 +144,16 @@ export class P2P extends EventEmitter {
 					const peerId = Peer.constructPeerId(socket.remoteAddress, wsPort);
 					const existingPeer = this._peerPool.getPeer(peerId);
 					if (existingPeer === undefined) {
-						const peer = new Peer({
-							inboundSocket: socket,
-							ipAddress: socket.remoteAddress,
-							os: queryObject.os,
-							version: queryObject.version,
-							wsPort,
-						});
+						const peer = new Peer(
+							{
+								ipAddress: socket.remoteAddress,
+								wsPort,
+								height: queryObject.height ? +queryObject.height : 0,
+								os: queryObject.os,
+								version: queryObject.version,
+							},
+							socket,
+						);
 						peer.applyNodeInfo(this._nodeInfo);
 						this._peerPool.addPeer(peer);
 						super.emit(EVENT_NEW_INBOUND_PEER, peer);
@@ -202,13 +205,13 @@ export class P2P extends EventEmitter {
 					procedure: 'list',
 				});
 				const peerListResponse = seedNodePeerListResponse.data as ProtocolPeerList;
-				
+
 				// TODO ASAP: Validate the response before returning. Check that seedNodePeerListResponse.data.peers exists.
 
 				return peerListResponse.peers.map((peerInfo: ProtocolPeerInfo) => {
 					const peer = new Peer({
-						ipAddress: peerInfo.ip,
-						wsPort: peerInfo.wsPort, // TODO ASAP: Add more properties
+						ipAddress: peerInfo.ip, // TODO ASAP: Add more properties
+						wsPort: peerInfo.wsPort,
 						height: peerInfo.height,
 						os: peerInfo.os,
 						version: peerInfo.version,

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -53,7 +53,7 @@ export class P2P extends EventEmitter {
 	private _isActive: boolean;
 	private readonly _newPeers: Set<PeerInfo>;
 
-	// TODO ASAP: private readonly _triedPeers: Set<PeerConfig>;
+	// TODO ASAP: private readonly _triedPeers: Set<PeerInfo>;
 	private _nodeInfo: P2PNodeInfo;
 	private readonly _peerPool: PeerPool;
 	private readonly _scServer: SCServerUpdated;
@@ -102,9 +102,10 @@ export class P2P extends EventEmitter {
 	}
 
 	public getNetworkStatus(): P2PNetworkStatus {
-		// TODO ASAP: Add additional properties.
+		// TODO ASAP: Add additional properties such as _triedPeers.
 		return {
-			peers: this._peerPool.getAllPeerInfos(),
+			newPeers: [...this._newPeers.values()],
+			activePeers: this._peerPool.getAllPeerInfos(),
 		};
 	}
 

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -77,14 +77,14 @@ export interface ProtocolPeerList {
 }
 
 // TODO later: Switch to LIP protocol format.
-export interface ProtocolInboundRPCRequest {
+export interface ProtocolRPCRequest {
 	readonly data: unknown;
 	readonly procedure: string;
 	readonly type: string;
 }
 
 // TODO later: Switch to LIP protocol format.
-export interface ProtocolInboundMessage {
+export interface ProtocolMessage {
 	readonly data: unknown;
 	readonly event: string;
 }

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -53,7 +53,6 @@ export interface P2PConfig {
 export interface P2PNetworkStatus {
 	readonly newPeers: ReadonlyArray<PeerInfo>;
 	readonly triedPeers: ReadonlyArray<PeerInfo>;
-	readonly availablePeers: ReadonlyArray<PeerInfo>;
 	readonly connectedPeers: ReadonlyArray<PeerInfo>;
 }
 

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -79,3 +79,9 @@ export interface ProtocolInboundRPCRequest {
 	readonly procedure: string;
 	readonly type: string;
 }
+
+// TODO later: Switch to LIP protocol format.
+export interface ProtocolInboundMessage {
+	readonly data: unknown;
+	readonly event: string;
+}

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -51,7 +51,8 @@ export interface P2PConfig {
 
 // Network info exposed by the P2P library.
 export interface P2PNetworkStatus {
-	readonly peers: ReadonlyArray<PeerInfo>;
+	readonly newPeers: ReadonlyArray<PeerInfo>;
+	readonly activePeers: ReadonlyArray<PeerInfo>;
 }
 
 // This is a representation of the peer object according to the current protocol.

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -17,8 +17,8 @@
 import { PeerInfo } from './peer';
 
 export interface P2PRequestPacket<T> {
-	readonly procedure: string;
 	readonly params?: T;
+	readonly procedure: string;
 }
 
 export interface P2PResponsePacket {
@@ -26,15 +26,15 @@ export interface P2PResponsePacket {
 }
 
 export interface P2PMessagePacket<T> {
-	readonly event: string;
 	readonly data: T;
+	readonly event: string;
 }
 
-export interface P2PNodeStatus {
-	readonly wsPort: number;
+export interface P2PNodeInfo {
+	readonly height: number;
 	readonly os: string;
 	readonly version: string;
-	readonly height: number;
+	readonly wsPort: number;
 }
 
 export interface P2PPenalty {}
@@ -44,28 +44,38 @@ export interface P2PConfig {
 	readonly connectTimeout: number;
 	readonly ipAddress?: string;
 	readonly seedPeers: ReadonlyArray<PeerInfo>;
+	readonly version: string;
 	readonly wsEngine?: string;
 	readonly wsPort: number;
-	readonly version: string;
 }
 
-export interface NetworkStatus {}
+// Network info exposed by the P2P library.
+export interface P2PNetworkStatus {
+	readonly peers: ReadonlyArray<PeerInfo>;
+}
 
 // This is a representation of the peer object according to the current protocol.
 // TODO later: Switch to LIP protocol format.
 export interface ProtocolPeerInfo {
-	readonly ip: string;
-	readonly wsPort: number;
-	readonly os: string;
-	readonly version: string;
 	readonly broadhash: string;
 	readonly height: number;
+	readonly ip: string;
 	readonly nonce: string;
+	readonly os: string;
+	readonly version: string;
+	readonly wsPort: number;
 }
 
 // This is a representation of the peer list according to the current protocol.
 // TODO later: Switch to LIP protocol format.
 export interface ProtocolPeerList {
-	readonly success: boolean;
 	readonly peers: ReadonlyArray<ProtocolPeerInfo>;
+	readonly success: boolean;
+}
+
+// TODO later: Switch to LIP protocol format.
+export interface ProtocolInboundRPCRequest {
+	readonly data: unknown;
+	readonly procedure: string;
+	readonly type: string;
 }

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -42,7 +42,7 @@ export interface P2PPenalty {}
 export interface P2PConfig {
 	readonly blacklistedPeers: ReadonlyArray<PeerInfo>;
 	readonly connectTimeout: number;
-	readonly ipAddress?: string;
+	readonly hostAddress?: string;
 	readonly seedPeers: ReadonlyArray<PeerInfo>;
 	readonly version: string;
 	readonly wsEngine?: string;
@@ -52,7 +52,9 @@ export interface P2PConfig {
 // Network info exposed by the P2P library.
 export interface P2PNetworkStatus {
 	readonly newPeers: ReadonlyArray<PeerInfo>;
-	readonly activePeers: ReadonlyArray<PeerInfo>;
+	readonly triedPeers: ReadonlyArray<PeerInfo>;
+	readonly availablePeers: ReadonlyArray<PeerInfo>;
+	readonly connectedPeers: ReadonlyArray<PeerInfo>;
 }
 
 // This is a representation of the peer object according to the current protocol.

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -13,8 +13,8 @@
  *
  */
 
-import { RPCResponseError } from './errors';
 import { EventEmitter } from 'events';
+import { RPCResponseError } from './errors';
 
 import {
 	P2PMessagePacket,
@@ -210,6 +210,15 @@ export class Peer extends EventEmitter {
 		}
 	}
 
+	public send<T>(packet: P2PMessagePacket<T>): void {
+		if (!this.outboundSocket) {
+			this.outboundSocket = this._createOutboundSocket();
+		}
+		this.outboundSocket.emit(packet.event, {
+			data: packet.data,
+		});
+	}
+
 	public async request<T>(
 		packet: P2PRequestPacket<T>,
 	): Promise<P2PResponsePacket> {
@@ -266,15 +275,6 @@ export class Peer extends EventEmitter {
 				this.wsPort,
 			);
 		}
-	}
-
-	public send<T>(packet: P2PMessagePacket<T>): void {
-		if (!this.outboundSocket) {
-			this.outboundSocket = this._createOutboundSocket();
-		}
-		this.outboundSocket.emit(packet.event, {
-			data: packet.data,
-		});
 	}
 
 	private _createOutboundSocket(): SCClientSocket {

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -36,9 +36,11 @@ export const EVENT_REQUEST_RECEIVED = 'requestReceived';
 export const EVENT_INVALID_MESSAGE_RECEIVED = 'invalidMessageReceived';
 export const EVENT_MESSAGE_RECEIVED = 'requestReceived';
 
-// Remote event names sent to or received from peers.
-export const REMOTE_EVENT_SEND_NODE_INFO = 'updateMyself';
+// Remote event or RPC names sent to or received from peers.
 export const REMOTE_EVENT_RPC_REQUEST = 'rpc-request';
+export const REMOTE_EVENT_SEND_NODE_INFO = 'updateMyself';
+export const REMOTE_RPC_GET_ALL_PEERS_LIST = 'list';
+
 
 export interface PeerInfo {
 	readonly ipAddress: string;
@@ -262,7 +264,7 @@ export class Peer extends EventEmitter {
 	public async fetchPeers(): Promise<ReadonlyArray<PeerInfo>> {
 		try {
 			const response: P2PResponsePacket = await this.request<void>({
-				procedure: GET_ALL_PEERS_LIST_RPC,
+				procedure: REMOTE_RPC_GET_ALL_PEERS_LIST,
 			});
 
 			return processPeerListFromResponse(response.data);
@@ -280,7 +282,7 @@ export class Peer extends EventEmitter {
 		return socketClusterClient.create({
 			hostname: this._ipAddress,
 			port: this._wsPort,
-			query: this._nodeInfo,
+			query: JSON.stringify(this._nodeInfo),
 			autoConnect: false,
 		});
 	}

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -96,7 +96,7 @@ export class Peer extends EventEmitter {
 				return;
 			}
 			if (
-				request.procedure === 'updateMyself' &&
+				request.procedure === REMOTE_EVENT_SEND_NODE_INFO &&
 				typeof request.data === 'object'
 			) {
 				// Internal handling of request to extract the PeerInfo.
@@ -196,7 +196,6 @@ export class Peer extends EventEmitter {
 		if (!this.outboundSocket) {
 			this.outboundSocket = this._createOutboundSocket();
 		}
-
 		this.outboundSocket.connect();
 	}
 

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -77,6 +77,7 @@ export class Peer extends EventEmitter {
 		}
 		this._height = peerInfo.height ? peerInfo.height : 0;
 
+		// This function needs to be defined as an arrow function inside the constructor in order to allow it to be added and removed as an event handler.
 		this._handlePeerInfo = (packet: unknown) => {
 			// TODO later: Switch to LIP protocol format.
 			// TODO ASAP: Move validation/sanitization to a separate file with other validation logic.

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -19,7 +19,7 @@
  */
 
 import { EventEmitter } from 'events';
-import { Peer } from './peer';
+import { Peer, PeerInfo } from './peer';
 
 export class PeerPool extends EventEmitter {
 	private readonly _peerMap: Map<string, Peer>;
@@ -29,8 +29,8 @@ export class PeerPool extends EventEmitter {
 		this._peerMap = new Map();
 	}
 
-	/* tslint:disable:next-line: prefer-function-over-method */
 	// TODO ASAP: Implement. Use PeerOptions type instead of any for selectionParams.
+	/* tslint:disable:next-line: prefer-function-over-method */
 	public selectPeers(
 		selectionParams: any,
 		numOfPeers: number,
@@ -41,25 +41,33 @@ export class PeerPool extends EventEmitter {
 		return [];
 	}
 
-	public hasPeer(peerId: string): boolean {
-		return this._peerMap.has(peerId);
-	}
-
 	public addPeer(peer: Peer): void {
 		this._peerMap.set(peer.id, peer);
-	}
-
-	public removePeer(peerId: string): boolean {
-		return this._peerMap.delete(peerId);
-	}
-
-	public getPeer(peerId: string): Peer | undefined {
-		return this._peerMap.get(peerId);
 	}
 
 	public disconnectAllPeers(): void {
 		this._peerMap.forEach((peer: Peer) => {
 			peer.disconnect();
 		});
+	}
+
+	public getAllPeerInfos(): ReadonlyArray<PeerInfo> {
+		return this.getAllPeers().map(peer => peer.peerInfo);
+	}
+
+	public getAllPeers(): ReadonlyArray<Peer> {
+		return [...this._peerMap.values()];
+	}
+
+	public getPeer(peerId: string): Peer | undefined {
+		return this._peerMap.get(peerId);
+	}
+
+	public hasPeer(peerId: string): boolean {
+		return this._peerMap.has(peerId);
+	}
+
+	public removePeer(peerId: string): boolean {
+		return this._peerMap.delete(peerId);
 	}
 }

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -1,12 +1,13 @@
+import { expect } from 'chai';
 import { P2P } from '../../src/index';
 
 describe.skip('Integration tests for P2P library', () => {
 	const NETWORK_PEER_COUNT = 10;
-	let blockchainP2PList: ReadonlyArray<P2P> = [];
+	let p2pNodeList: ReadonlyArray<P2P> = [];
 
-	describe('Start and stop network', () => {
+	describe('Disconnected network', () => {
 		beforeEach(async () => {
-			blockchainP2PList = [...Array(NETWORK_PEER_COUNT).keys()].map(index => {
+			p2pNodeList = [...Array(NETWORK_PEER_COUNT).keys()].map(index => {
 				return new P2P({
 					blacklistedPeers: [],
 					connectTimeout: 5000,
@@ -17,24 +18,62 @@ describe.skip('Integration tests for P2P library', () => {
 				});
 			});
 
-			let peerStartPromises: ReadonlyArray<
-				Promise<void>
-			> = blockchainP2PList.map(blockchainP2P => {
-				return blockchainP2P.start();
-			});
+			let peerStartPromises: ReadonlyArray<Promise<void>> = p2pNodeList.map(
+				p2p => {
+					return p2p.start();
+				},
+			);
 			await Promise.all(peerStartPromises);
 		});
 
 		afterEach(async () => {
 			await Promise.all(
-				blockchainP2PList.map(p2p => {
+				p2pNodeList.map(p2p => {
 					return p2p.stop();
 				}),
 			);
 		});
 
-		it('should launch a network of peers locally', () => {
-			// TODO: Check that nodes are running.
+		it('should set the isActive property to true for all nodes', () => {
+			p2pNodeList.forEach(p2p => {
+				expect(p2p).to.have.property('isActive', true);
+			});
+		});
+	});
+
+	describe.skip('Fully connected network', () => {
+		beforeEach(async () => {
+			p2pNodeList = [...Array(NETWORK_PEER_COUNT).keys()].map(index => {
+				return new P2P({
+					blacklistedPeers: [],
+					connectTimeout: 5000,
+					seedPeers: [],
+					wsEngine: 'ws',
+					wsPort: 5000 + index,
+					version: '1.0.0',
+				});
+			});
+
+			let peerStartPromises: ReadonlyArray<Promise<void>> = p2pNodeList.map(
+				blockchainP2P => {
+					return blockchainP2P.start();
+				},
+			);
+			await Promise.all(peerStartPromises);
+		});
+
+		afterEach(async () => {
+			await Promise.all(
+				p2pNodeList.map(p2p => {
+					return p2p.stop();
+				}),
+			);
+		});
+
+		describe('Seed peer discovery', () => {
+			it('should discover seed peers', () => {
+				// TODO: Check that nodes are running and connected to seed peers using p2p.getNetworkStatus()
+			});
 		});
 	});
 });

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -18,7 +18,7 @@ describe.skip('Integration tests for P2P library', () => {
 				});
 			});
 
-			let peerStartPromises: ReadonlyArray<Promise<void>> = p2pNodeList.map(
+			const peerStartPromises: ReadonlyArray<Promise<void>> = p2pNodeList.map(
 				p2p => {
 					return p2p.start();
 				},
@@ -54,7 +54,7 @@ describe.skip('Integration tests for P2P library', () => {
 				});
 			});
 
-			let peerStartPromises: ReadonlyArray<Promise<void>> = p2pNodeList.map(
+			const peerStartPromises: ReadonlyArray<Promise<void>> = p2pNodeList.map(
 				blockchainP2P => {
 					return blockchainP2P.start();
 				},

--- a/packages/lisk-p2p/test/utils/peers.ts
+++ b/packages/lisk-p2p/test/utils/peers.ts
@@ -22,6 +22,7 @@ export const initializePeerInfoList = (): ReadonlyArray<PeerInfo> => {
 		version: '1.0.1',
 		os: 'darwin',
 	};
+
 	const peerOption2: PeerInfo = {
 		ipAddress: '127.0.0.1',
 		wsPort: 5002,
@@ -29,6 +30,7 @@ export const initializePeerInfoList = (): ReadonlyArray<PeerInfo> => {
 		version: '1.0.1',
 		os: 'darwin',
 	};
+
 	const peerOption3: PeerInfo = {
 		ipAddress: '18.28.48.1',
 		wsPort: 5008,
@@ -36,6 +38,7 @@ export const initializePeerInfoList = (): ReadonlyArray<PeerInfo> => {
 		version: '1.4.1',
 		os: 'darwin',
 	};
+	
 	const peerOption4: PeerInfo = {
 		ipAddress: '192.28.138.1',
 		wsPort: 5006,
@@ -43,6 +46,7 @@ export const initializePeerInfoList = (): ReadonlyArray<PeerInfo> => {
 		version: '1.0.1',
 		os: 'darwin',
 	};
+
 	const peerOption5: PeerInfo = {
 		ipAddress: '178.21.90.199',
 		wsPort: 5001,


### PR DESCRIPTION
### What was the problem?

In order to implement the integration tests, there needs to be a way to get information about the network's state from the P2P library. This feature depends on the `P2P.getNetworkStatus()` method of the P2P library which itself depends on the peer request/send functionality (to allow peers to send us information about themselves).

### How did I fix it?

- Implemented outbound request/send functionality (at the `Peer` level only)
- Implemented inbound request/message handling (at the `Peer` level only)
- Implemented sending of `P2PNodeInfo` to remote peers.
- Implemented receiving `PeerInfo` from remote peers.
- Implemented `getNetworkStatus()` method on `P2P` class.

### How to test it?

Will add integration tests for all these features as part of #953 then, once passing, the logic can be locked down with unit tests.

### Review checklist

* The PR resolves #985 and #897 
* The PR addresses #896 and #953
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
