### PR TITLE
Remove asset field from base transaction - Closes #989

### DIFF
--- a/packages/lisk-transactions/src/transactions/base.ts
+++ b/packages/lisk-transactions/src/transactions/base.ts
@@ -152,7 +152,7 @@ export abstract class BaseTransaction {
 		};
 
 		return transaction;
-	}	
+	}
 
 	public getBytes(): Buffer {
 		const transactionBytes = Buffer.concat([

--- a/packages/lisk-transactions/src/transactions/base.ts
+++ b/packages/lisk-transactions/src/transactions/base.ts
@@ -33,7 +33,6 @@ import { TransactionError, TransactionMultiError } from '../errors';
 import {
 	Account,
 	Status,
-	TransactionAsset,
 	TransactionJSON,
 } from '../transaction_types';
 import {
@@ -73,8 +72,7 @@ export abstract class BaseTransaction {
 	public readonly signatures: ReadonlyArray<string> = [];
 	public readonly timestamp: number;
 	public readonly type: number;
-	public readonly asset: TransactionAsset = {};
-	public readonly receivedAt: Date;
+	public readonly receivedAt: Date = new Date();
 	public readonly containsUniqueData?: boolean;
 	public isMultisignature: MultisignatureStatus = MultisignatureStatus.UNKNOWN;
 
@@ -82,7 +80,7 @@ export abstract class BaseTransaction {
 	private _signature?: string;
 	private _signSignature?: string;
 
-	public abstract assetToJSON(): TransactionAsset;
+	public abstract assetToJSON(): object;
 	public abstract verifyAgainstOtherTransactions(
 		transactions: ReadonlyArray<TransactionJSON>,
 	): TransactionResponse;
@@ -99,7 +97,6 @@ export abstract class BaseTransaction {
 		}
 
 		this.amount = new BigNum(rawTransaction.amount);
-		this.asset = rawTransaction.asset;
 		this.fee = new BigNum(rawTransaction.fee);
 		this._id = rawTransaction.id;
 		this.recipientId = rawTransaction.recipientId;
@@ -155,7 +152,7 @@ export abstract class BaseTransaction {
 		};
 
 		return transaction;
-	}
+	}	
 
 	public getBytes(): Buffer {
 		const transactionBytes = Buffer.concat([
@@ -460,18 +457,13 @@ export abstract class BaseTransaction {
 			size: BYTESIZES.AMOUNT,
 		});
 
-		const transactionAsset =
-			this.asset && Object.keys(this.asset).length
-				? this.getAssetBytes()
-				: Buffer.alloc(0);
-
 		return Buffer.concat([
 			transactionType,
 			transactionTimestamp,
 			transactionSenderPublicKey,
 			transactionRecipientID,
 			transactionAmount,
-			transactionAsset,
+			this.getAssetBytes(),
 		]);
 	}
 }


### PR DESCRIPTION
### What was the problem?
In order to make the base transaction more flexible yet type safe, asset should not be defined in the base transaction.

### How did I fix it?
Remove the asset field from the base transaction

### Review checklist

* The PR resolves #989 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
