### PR TITLE
Use discover peers function in p2p - Closes#979

### DIFF
--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -208,7 +208,7 @@ export class P2P extends EventEmitter {
 			this._config.seedPeers,
 		);
 		// Add all the discovered peers in newPeer list
-		discoveredPeers.map((peerInfo: PeerInfo) => {
+		discoveredPeers.forEach((peerInfo: PeerInfo) => {
 			this._newPeers.add(peerInfo);
 		});
 	}


### PR DESCRIPTION
### Description

Use discovery in P2P to find new peers. It should take initial peers on which the discovery algo will run and then it will return all the relevant peers based on the algo and add it to `newPeers` list.

* The PR resolves #979 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
