### PR TITLE
Use peer selection to choose peers for connection in p2p - Closes#978

### DIFF
--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -206,17 +206,13 @@ export class P2P extends EventEmitter {
 		});
 	}
 
-	private _getPeerToConnect(): ReadonlyArray<Peer> {
+	private _connectToPeers(): void {
 		const availablePeers = Array.from(this._newPeers).map(
 			(peerInfo: PeerInfo) => new Peer(peerInfo),
 		);
+
 		const peersToConnect = selectForConnection(availablePeers);
-
-		return peersToConnect;
-	}
-
-	private _connectToPeers(): void {
-		this._getPeerToConnect().map((peer: Peer) => {
+		peersToConnect.map((peer: Peer) => {
 			peer.connect();
 			this._newPeers.delete(peer.peerInfo);
 			this._triedPeers.add(peer.peerInfo);

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -212,7 +212,7 @@ export class P2P extends EventEmitter {
 		);
 
 		const peersToConnect = selectForConnection(availablePeers);
-		peersToConnect.map((peer: Peer) => {
+		peersToConnect.forEach((peer: Peer) => {
 			peer.connect();
 			this._newPeers.delete(peer.peerInfo);
 			this._triedPeers.add(peer.peerInfo);

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -213,8 +213,8 @@ export class P2P extends EventEmitter {
 		);
 
 		const peersToConnect = selectForConnection(availablePeers);
-		peersToConnect.forEach(async (peer: Peer) => {
-			await peer.connect();
+		peersToConnect.forEach((peer: Peer) => {
+			peer.connect();
 			this._newPeers.delete(peer.peerInfo);
 			this._triedPeers.add(peer.peerInfo);
 		});

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -22,8 +22,7 @@ import { attach, SCServer, SCServerSocket } from 'socketcluster-server';
 import { RequestFailError } from './errors';
 import { ConnectionState, Peer, PeerInfo } from './peer';
 import { discoverPeers } from './peer_discovery';
-import { PeerOptions } from './peer_selection';
-import { selectForConnection } from './peer_selection';
+import { PeerOptions, selectForConnection } from './peer_selection';
 
 import {
 	P2PConfig,

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -178,11 +178,11 @@ export class P2P extends EventEmitter {
 						super.emit(EVENT_NEW_INBOUND_PEER, peer);
 						super.emit(EVENT_NEW_PEER, peer);
 						this._newPeers.add(peer.peerInfo);
-					} else {
-						if (existingPeer.state.inbound === ConnectionState.DISCONNECTED) {
-							existingPeer.inboundSocket = socket;
-							this._newPeers.add(existingPeer.peerInfo);
-						}
+					} else if (
+						existingPeer.state.inbound === ConnectionState.DISCONNECTED
+					) {
+						existingPeer.inboundSocket = socket;
+						this._newPeers.add(existingPeer.peerInfo);
 					}
 				}
 			},

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -193,17 +193,11 @@ export class Peer extends EventEmitter {
 		return this._nodeInfo;
 	}
 
-	public async connect(): Promise<void> {
-
-		return new Promise<void>(resolve => {
-			if (!this._outboundSocket) {
-				this._outboundSocket = this._createOutboundSocket();
-			}
-			this._outboundSocket.connect();
-			this._outboundSocket.on('connect', _ => {
-				resolve();
-			});
-		});
+	public connect(): void {
+		if (!this._outboundSocket) {
+			this._outboundSocket = this._createOutboundSocket();
+		}
+		this._outboundSocket.connect();
 	}
 
 	public disconnect(code: number = 1000, reason?: string): void {

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -193,11 +193,17 @@ export class Peer extends EventEmitter {
 		return this._nodeInfo;
 	}
 
-	public connect(): void {
-		if (!this._outboundSocket) {
-			this._outboundSocket = this._createOutboundSocket();
-		}
-		this._outboundSocket.connect();
+	public async connect(): Promise<void> {
+
+		return new Promise<void>(resolve => {
+			if (!this._outboundSocket) {
+				this._outboundSocket = this._createOutboundSocket();
+			}
+			this._outboundSocket.connect();
+			this._outboundSocket.on('connect', _ => {
+				resolve();
+			});
+		});
 	}
 
 	public disconnect(code: number = 1000, reason?: string): void {


### PR DESCRIPTION
### Description

Use peer selection for connection method to choose peers to connect in p2p class.

### Review checklist

* The PR resolves #978
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
