### PR TITLE
Allow empty id and signature for constructor - Closes #995

### DIFF
--- a/packages/lisk-transactions/src/transaction_types.ts
+++ b/packages/lisk-transactions/src/transaction_types.ts
@@ -48,17 +48,17 @@ export interface TransactionJSON {
 	readonly amount: string;
 	readonly asset: TransactionAsset;
 	readonly fee: string;
-	readonly id: string;
+	readonly id?: string;
 	readonly recipientId: string;
-	readonly recipientPublicKey: string;
-	readonly senderId: string;
+	readonly recipientPublicKey?: string;
+	readonly senderId?: string;
 	readonly senderPublicKey: string;
 	readonly signature?: string;
 	readonly signatures: ReadonlyArray<string>;
 	readonly signSignature?: string;
 	readonly timestamp: number;
 	readonly type: number;
-	readonly receivedAt: Date;
+	readonly receivedAt?: Date;
 }
 
 export interface IsValidResponse {

--- a/packages/lisk-transactions/src/transactions/base.ts
+++ b/packages/lisk-transactions/src/transactions/base.ts
@@ -158,8 +158,8 @@ export abstract class BaseTransaction {
 	public getBytes(): Buffer {
 		const transactionBytes = Buffer.concat([
 			this.getBasicBytes(),
-			this.signature ? hexToBuffer(this.signature) : Buffer.alloc(0),
-			this.signSignature ? hexToBuffer(this.signSignature) : Buffer.alloc(0),
+			this._signature ? hexToBuffer(this._signature) : Buffer.alloc(0),
+			this._signSignature ? hexToBuffer(this._signSignature) : Buffer.alloc(0),
 		]);
 
 		return transactionBytes;

--- a/packages/lisk-transactions/src/transactions/base.ts
+++ b/packages/lisk-transactions/src/transactions/base.ts
@@ -15,7 +15,7 @@
 // tslint:disable-next-line no-reference
 /// <reference path="../../types/browserify-bignum/index.d.ts" />
 
-import * as cryptography from '@liskhq/lisk-cryptography';
+import { bigNumberToBuffer, getAddressFromPublicKey, hexToBuffer } from '@liskhq/lisk-cryptography';
 import BigNum from 'browserify-bignum';
 import {
 	BYTESIZES,
@@ -39,7 +39,6 @@ import {
 	verifySignature,
 } from '../utils';
 import * as schemas from '../utils/validation/schema';
-import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
 
 export interface TransactionResponse {
 	readonly id: string;
@@ -156,10 +155,10 @@ export abstract class BaseTransaction {
 		const transactionBytes = Buffer.concat([
 			this.getBasicBytes(),
 			this.signature
-				? cryptography.hexToBuffer(this.signature)
+				? hexToBuffer(this.signature)
 				: Buffer.alloc(0),
 			this.signSignature
-				? cryptography.hexToBuffer(this.signSignature)
+				? hexToBuffer(this.signSignature)
 				: Buffer.alloc(0),
 		]);
 
@@ -185,7 +184,7 @@ export abstract class BaseTransaction {
 			// `senderPublicKey` passed format check, safely check equality to senderId
 			if (
 				this.senderId.toUpperCase() !==
-				cryptography.getAddressFromPublicKey(this.senderPublicKey).toUpperCase()
+				getAddressFromPublicKey(this.senderPublicKey).toUpperCase()
 			) {
 				errors.push(
 					new TransactionError(
@@ -253,7 +252,7 @@ export abstract class BaseTransaction {
 
 	public getRequiredAttributes(): Attributes {
 		return {
-			ACCOUNTS: [cryptography.getAddressFromPublicKey(this.senderPublicKey)],
+			ACCOUNTS: [getAddressFromPublicKey(this.senderPublicKey)],
 		};
 	}
 
@@ -313,7 +312,7 @@ export abstract class BaseTransaction {
 			} else {
 				const transactionBytes = Buffer.concat([
 					this.getBasicBytes(),
-					cryptography.hexToBuffer(this.signature),
+					hexToBuffer(this.signature),
 				]);
 
 				const {
@@ -433,12 +432,12 @@ export abstract class BaseTransaction {
 		const transactionTimestamp = Buffer.alloc(BYTESIZES.TIMESTAMP);
 		transactionTimestamp.writeIntLE(this.timestamp, 0, BYTESIZES.TIMESTAMP);
 
-		const transactionSenderPublicKey = cryptography.hexToBuffer(
+		const transactionSenderPublicKey = hexToBuffer(
 			this.senderPublicKey,
 		);
 
 		const transactionRecipientID = this.recipientId
-			? cryptography.bigNumberToBuffer(
+			? bigNumberToBuffer(
 					this.recipientId.slice(0, -1),
 					BYTESIZES.RECIPIENT_ID,
 			  )

--- a/packages/lisk-transactions/src/transactions/base.ts
+++ b/packages/lisk-transactions/src/transactions/base.ts
@@ -15,7 +15,11 @@
 // tslint:disable-next-line no-reference
 /// <reference path="../../types/browserify-bignum/index.d.ts" />
 
-import { bigNumberToBuffer, getAddressFromPublicKey, hexToBuffer } from '@liskhq/lisk-cryptography';
+import {
+	bigNumberToBuffer,
+	getAddressFromPublicKey,
+	hexToBuffer,
+} from '@liskhq/lisk-cryptography';
 import BigNum from 'browserify-bignum';
 import {
 	BYTESIZES,
@@ -154,12 +158,8 @@ export abstract class BaseTransaction {
 	public getBytes(): Buffer {
 		const transactionBytes = Buffer.concat([
 			this.getBasicBytes(),
-			this.signature
-				? hexToBuffer(this.signature)
-				: Buffer.alloc(0),
-			this.signSignature
-				? hexToBuffer(this.signSignature)
-				: Buffer.alloc(0),
+			this.signature ? hexToBuffer(this.signature) : Buffer.alloc(0),
+			this.signSignature ? hexToBuffer(this.signSignature) : Buffer.alloc(0),
 		]);
 
 		return transactionBytes;
@@ -432,15 +432,10 @@ export abstract class BaseTransaction {
 		const transactionTimestamp = Buffer.alloc(BYTESIZES.TIMESTAMP);
 		transactionTimestamp.writeIntLE(this.timestamp, 0, BYTESIZES.TIMESTAMP);
 
-		const transactionSenderPublicKey = hexToBuffer(
-			this.senderPublicKey,
-		);
+		const transactionSenderPublicKey = hexToBuffer(this.senderPublicKey);
 
 		const transactionRecipientID = this.recipientId
-			? bigNumberToBuffer(
-					this.recipientId.slice(0, -1),
-					BYTESIZES.RECIPIENT_ID,
-			  )
+			? bigNumberToBuffer(this.recipientId.slice(0, -1), BYTESIZES.RECIPIENT_ID)
 			: Buffer.alloc(BYTESIZES.RECIPIENT_ID);
 
 		const transactionAmount = this.amount.toBuffer({

--- a/packages/lisk-transactions/src/utils/validation/schema.ts
+++ b/packages/lisk-transactions/src/utils/validation/schema.ts
@@ -16,16 +16,13 @@ export const transaction = {
 	$id: 'lisk/transaction',
 	type: 'object',
 	required: [
-		'id',
 		'type',
 		'amount',
 		'fee',
 		'senderPublicKey',
-		'senderId',
 		'recipientId',
 		'timestamp',
 		'asset',
-		'signature',
 	],
 	properties: {
 		id: {
@@ -85,6 +82,7 @@ export const baseTransaction = {
 		'type',
 		'amount',
 		'fee',
+		'senderId',
 		'senderPublicKey',
 		'timestamp',
 		'asset',

--- a/packages/lisk-transactions/src/utils/validation/schema.ts
+++ b/packages/lisk-transactions/src/utils/validation/schema.ts
@@ -82,7 +82,6 @@ export const baseTransaction = {
 		'type',
 		'amount',
 		'fee',
-		'senderId',
 		'senderPublicKey',
 		'timestamp',
 		'asset',

--- a/packages/lisk-transactions/test/helpers/add_transaction_fields.ts
+++ b/packages/lisk-transactions/test/helpers/add_transaction_fields.ts
@@ -1,7 +1,9 @@
 export const addTransactionFields = (transaction: any) => {
 	return {
 		...transaction,
-		signSignature: transaction.signSignature ? transaction.signSignature : undefined,
+		signSignature: transaction.signSignature
+			? transaction.signSignature
+			: undefined,
 		receivedAt: new Date(),
 	};
 };

--- a/packages/lisk-transactions/test/transactions/base.ts
+++ b/packages/lisk-transactions/test/transactions/base.ts
@@ -323,12 +323,12 @@ describe('Base transaction class', () => {
 		});
 	});
 
-	describe('#checkSchema', () => {
+	describe('#validateSchema', () => {
 		it('should call toJSON', async () => {
 			const toJSONStub = sandbox
 				.stub(validTestTransaction, 'toJSON')
 				.returns({});
-			validTestTransaction.checkSchema();
+			validTestTransaction.validateSchema();
 
 			expect(toJSONStub).to.be.calledOnce;
 		});
@@ -337,7 +337,7 @@ describe('Base transaction class', () => {
 			const cryptographyGetAddressFromPublicKeyStub = sandbox
 				.stub(cryptography, 'getAddressFromPublicKey')
 				.returns('18278674964748191682L');
-			validTestTransaction.checkSchema();
+			validTestTransaction.validateSchema();
 
 			expect(
 				cryptographyGetAddressFromPublicKeyStub,
@@ -353,7 +353,7 @@ describe('Base transaction class', () => {
 						'hex',
 					),
 				);
-			validTestTransaction.checkSchema();
+			validTestTransaction.validateSchema();
 			expect(getBytesStub).to.be.calledOnce;
 		});
 
@@ -361,13 +361,13 @@ describe('Base transaction class', () => {
 			const getIdStub = sandbox
 				.stub(utils, 'getId')
 				.returns('15822870279184933850');
-			validTestTransaction.checkSchema();
+			validTestTransaction.validateSchema();
 
 			expect(getIdStub).to.be.calledOnce;
 		});
 
 		it('should return a successful transaction response with a valid transaction', async () => {
-			const { id, status, errors } = validTestTransaction.checkSchema();
+			const { id, status, errors } = validTestTransaction.validateSchema();
 
 			expect(id).to.be.eql(validTestTransaction.id);
 			expect(errors).to.be.eql([]);
@@ -390,7 +390,7 @@ describe('Base transaction class', () => {
 			const invalidTestTransaction = new TestTransaction(
 				invalidTransaction as any,
 			);
-			const { id, status, errors } = invalidTestTransaction.checkSchema();
+			const { id, status, errors } = invalidTestTransaction.validateSchema();
 
 			expect(id).to.be.eql(invalidTestTransaction.id);
 			(errors as ReadonlyArray<TransactionError>).forEach(error =>
@@ -411,7 +411,7 @@ describe('Base transaction class', () => {
 				id,
 				status,
 				errors,
-			} = invalidSenderIdTestTransaction.checkSchema();
+			} = invalidSenderIdTestTransaction.validateSchema();
 
 			expect(id).to.be.eql(invalidSenderIdTestTransaction.id);
 			expect((errors as ReadonlyArray<TransactionError>)[1])
@@ -432,7 +432,7 @@ describe('Base transaction class', () => {
 			const invalidIdTestTransaction = new TestTransaction(
 				invalidIdTransaction as any,
 			);
-			const { id, status, errors } = invalidIdTestTransaction.checkSchema();
+			const { id, status, errors } = invalidIdTestTransaction.validateSchema();
 
 			expect(id).to.be.eql(invalidIdTestTransaction.id);
 			expect((errors as ReadonlyArray<TransactionError>)[0])
@@ -546,7 +546,7 @@ describe('Base transaction class', () => {
 			const cryptographyGetAddressFromPublicKeyStub = sandbox
 				.stub(cryptography, 'getAddressFromPublicKey')
 				.returns('18278674964748191682L');
-			validTestTransaction.checkSchema();
+			validTestTransaction.validateSchema();
 
 			expect(
 				cryptographyGetAddressFromPublicKeyStub,
@@ -902,13 +902,15 @@ describe('Base transaction class', () => {
 			expect(state)
 				.to.be.an('object')
 				.and.to.have.property('sender');
-			expect((state as any).sender).to.have.property('balance', new BigNum(MAX_TRANSACTION_AMOUNT).add(validTestTransaction.fee).toString());
+			expect((state as any).sender).to.have.property(
+				'balance',
+				new BigNum(MAX_TRANSACTION_AMOUNT)
+					.add(validTestTransaction.fee)
+					.toString(),
+			);
 			expect((errors as ReadonlyArray<TransactionError>)[0])
 				.to.be.instanceof(TransactionError)
-				.and.to.have.property(
-					'message',
-					'Invalid balance amount',
-				);
+				.and.to.have.property('message', 'Invalid balance amount');
 		});
 	});
 

--- a/packages/lisk-transactions/test/utils/sign_and_verify.ts
+++ b/packages/lisk-transactions/test/utils/sign_and_verify.ts
@@ -60,7 +60,8 @@ describe('signAndVerify module', () => {
 				.stub(cryptography, 'hash')
 				.returns(
 					Buffer.from(
-						'62b13b81836f3f1e371eba2f7f8306ff23d00a87d9473793eda7f742f4cfc21c', 'hex'
+						'62b13b81836f3f1e371eba2f7f8306ff23d00a87d9473793eda7f742f4cfc21c',
+						'hex',
 					),
 				);
 

--- a/tslint.json
+++ b/tslint.json
@@ -29,6 +29,6 @@
 		"readonly-keyword": [true, "ignore-class"],
 		"strict-boolean-expressions": false,
 		"strict-type-predicates": false,
-		"member-ordering": false
+		"variable-name": [true, "allow-leading-underscore"]
 	}
 }


### PR DESCRIPTION
### What was the problem?
Transaction instance was not able to be created without id and signature or senderId

### How did I fix it?
Allow id and signature to be optional, but when it used and not set, it will throw an error

### How to test it?
```
npm test
```

### Review checklist

* The PR resolves #995 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
