### PR TITLE
Add sign transaction feature in BaseTransaction

### DIFF
--- a/packages/lisk-transactions/src/transactions/base.ts
+++ b/packages/lisk-transactions/src/transactions/base.ts
@@ -18,6 +18,7 @@
 import {
 	bigNumberToBuffer,
 	getAddressFromPublicKey,
+	hash,
 	hexToBuffer,
 	signData,
 } from '@liskhq/lisk-cryptography';
@@ -431,9 +432,9 @@ export abstract class BaseTransaction {
 	public sign(passphrase: string, secondPassphrase?: string): void {
 		this._signature = undefined;
 		this._signSignature = undefined;
-		this._signature = signData(this.getBasicBytes(), passphrase);
+		this._signature = signData(hash(this.getBasicBytes()), passphrase);
 		if (secondPassphrase) {
-			this._signSignature = signData(this.getBytes(), passphrase);
+			this._signSignature = signData(hash(this.getBytes()), passphrase);
 		}
 		this._id = getId(this.getBytes());
 	}

--- a/packages/lisk-transactions/src/transactions/base.ts
+++ b/packages/lisk-transactions/src/transactions/base.ts
@@ -432,9 +432,9 @@ export abstract class BaseTransaction {
 	public sign(passphrase: string, secondPassphrase?: string): void {
 		this._signature = undefined;
 		this._signSignature = undefined;
-		this._signature = signData(hash(this.getBasicBytes()), passphrase);
+		this._signature = signData(hash(this.getBytes()), passphrase);
 		if (secondPassphrase) {
-			this._signSignature = signData(hash(this.getBytes()), passphrase);
+			this._signSignature = signData(hash(this.getBytes()), secondPassphrase);
 		}
 		this._id = getId(this.getBytes());
 	}

--- a/packages/lisk-transactions/test/transactions/base.ts
+++ b/packages/lisk-transactions/test/transactions/base.ts
@@ -13,6 +13,7 @@
  *
  */
 import { expect } from 'chai';
+import { SinonStub } from 'sinon';
 import * as cryptography from '@liskhq/lisk-cryptography';
 import { BYTESIZES, MAX_TRANSACTION_AMOUNT } from '../../src/constants';
 import {
@@ -32,7 +33,6 @@ import {
 	validSecondSignatureTransaction,
 } from '../../fixtures';
 import * as utils from '../../src/utils';
-import { SinonStub } from 'sinon';
 
 describe('Base transaction class', () => {
 	const defaultTransaction = addTransactionFields(validTransaction);


### PR DESCRIPTION
### What was the problem?
There was no functionality to sign the transaction from the base class.

### How did I fix it?
Add `sign` method for the transaction

### Review checklist

* The PR resolves #997 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
