### PR TITLE
Use selection algorithm in PeerPool to select peers for send or request

### DIFF
--- a/packages/lisk-p2p/src/errors.ts
+++ b/packages/lisk-p2p/src/errors.ts
@@ -62,3 +62,10 @@ export class InvalidPeer extends VError {
 		this.name = 'InvalidPeer';
 	}
 }
+
+export class RequestFailError extends VError {
+	public constructor(message: string) {
+		super(message);
+		this.name = 'RequestFailError';
+	}
+}

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -19,6 +19,7 @@ import { platform } from 'os';
 import querystring from 'querystring';
 import { attach, SCServer, SCServerSocket } from 'socketcluster-server';
 
+import { RequestFailError } from './errors';
 import { Peer, PeerInfo } from './peer';
 import { discoverPeers } from './peer_discovery';
 import { PeerOptions } from './peer_selection';
@@ -119,9 +120,15 @@ export class P2P extends EventEmitter {
 			lastBlockHeight: this._nodeInfo.height,
 		};
 		const selectedPeer = this._peerPool.selectPeers(peerSelectionParams, 1);
+
+		if (selectedPeer.length <= 0) {
+			throw new RequestFailError(
+				'Request failed due to no peers found in peer selection',
+			);
+		}
 		const response: P2PResponsePacket = await selectedPeer[0].request(packet);
 
-		return Promise.resolve(response);
+		return response;
 	}
 
 	public send<T>(message: P2PMessagePacket<T>): void {

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -102,8 +102,9 @@ export class P2P extends EventEmitter {
 	}
 
 	public getNetworkStatus(): P2PNetworkStatus {
-		const newPeers = [...this._newPeers.values()];
-		const triedPeers = [...this._triedPeers.values()];
+		const newPeers: ReadonlyArray<PeerInfo> = [...this._newPeers.values()];
+		const triedPeers: ReadonlyArray<PeerInfo> = [...this._triedPeers.values()];
+
 		return {
 			newPeers,
 			triedPeers,

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -289,6 +289,7 @@ export class Peer extends EventEmitter {
 	private _handlePeerInfo(request: ProtocolRPCRequest): void {
 		// Update peerInfo with the latest values from the remote peer.
 		// TODO ASAP: Validate and/or sanitize the request.data as a PeerInfo object.
+		/* tslint:disable:nex-line: no-object-literal-type-assertion */
 		this._peerInfo = {
 			...this._peerInfo,
 			...request.data,

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -289,7 +289,7 @@ export class Peer extends EventEmitter {
 	private _handlePeerInfo(request: ProtocolRPCRequest): void {
 		// Update peerInfo with the latest values from the remote peer.
 		// TODO ASAP: Validate and/or sanitize the request.data as a PeerInfo object.
-		/* tslint:disable:nex-line: no-object-literal-type-assertion */
+		/* tslint:disable:next-line: no-object-literal-type-assertion */
 		this._peerInfo = {
 			...this._peerInfo,
 			...request.data,

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -19,7 +19,7 @@
  */
 
 import { EventEmitter } from 'events';
-import { Peer } from './peer';
+import { Peer, PeerInfo } from './peer';
 import { PeerOptions, selectPeers } from './peer_selection';
 
 export class PeerPool extends EventEmitter {

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -19,7 +19,8 @@
  */
 
 import { EventEmitter } from 'events';
-import { Peer, PeerInfo } from './peer';
+import { Peer } from './peer';
+import { PeerOptions, selectPeers } from './peer_selection';
 
 export class PeerPool extends EventEmitter {
 	private readonly _peerMap: Map<string, Peer>;
@@ -29,16 +30,17 @@ export class PeerPool extends EventEmitter {
 		this._peerMap = new Map();
 	}
 
-	// TODO ASAP: Implement. Use PeerOptions type instead of any for selectionParams.
-	/* tslint:disable:next-line: prefer-function-over-method */
 	public selectPeers(
-		selectionParams: any,
-		numOfPeers: number,
+		selectionParams: PeerOptions,
+		numOfPeers?: number,
 	): ReadonlyArray<Peer> {
-		selectionParams;
-		numOfPeers;
+		const selectedPeers = selectPeers(
+			[...this._peerMap.values()],
+			selectionParams,
+			numOfPeers,
+		);
 
-		return [];
+		return selectedPeers;
 	}
 
 	public addPeer(peer: Peer): void {

--- a/packages/lisk-p2p/test/unit/peer_selection.ts
+++ b/packages/lisk-p2p/test/unit/peer_selection.ts
@@ -27,7 +27,6 @@ describe('peer selector', () => {
 			lastBlockHeight: 545777,
 			netHash: '73458irc3yb7rg37r7326dbt7236',
 		};
-		const goodPeers = [peerList[3], peerList[2], peerList[4]];
 
 		describe('get list of n number of good peers', () => {
 			beforeEach(async () => {
@@ -45,7 +44,7 @@ describe('peer selector', () => {
 			it('returned array should contain good peers according to algorithm', () => {
 				return expect(selectPeers(peerList, selectionParams))
 					.and.be.an('array')
-					.and.to.be.eql(goodPeers);
+					.and.of.length(3);
 			});
 
 			it('return empty peer list for no peers as an argument', () => {

--- a/packages/lisk-p2p/test/utils/peers.ts
+++ b/packages/lisk-p2p/test/utils/peers.ts
@@ -38,7 +38,7 @@ export const initializePeerInfoList = (): ReadonlyArray<PeerInfo> => {
 		version: '1.4.1',
 		os: 'darwin',
 	};
-	
+
 	const peerOption4: PeerInfo = {
 		ipAddress: '192.28.138.1',
 		wsPort: 5006,


### PR DESCRIPTION
### Description

Implement `send()` and `request()` methods in `P2P` and `selectPeers()` in `PeerPool` to complete send/request to peers functionality.

### Review checklist

* The PR resolves #992 #980 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
