### PR TITLE
Add InTransfer transaction

### DIFF
--- a/packages/lisk-transactions/fixtures/index.ts
+++ b/packages/lisk-transactions/fixtures/index.ts
@@ -13,6 +13,7 @@
  *
  */
 import validAccount from './valid_account.json';
+import validInTransferTransactions from './valid_in_transfer_transaction.json';
 import validMultisignatureAccount from './valid_multisignature_account.json';
 import validSecondSignatureAccount from './valid_second_signature_account.json';
 import validTransaction from './valid_transaction.json';
@@ -28,4 +29,5 @@ export {
 	validSecondSignatureAccount,
 	validSecondSignatureTransaction,
 	validVoteTransactions,
+	validInTransferTransactions,
 };

--- a/packages/lisk-transactions/fixtures/valid_in_transfer_transaction.json
+++ b/packages/lisk-transactions/fixtures/valid_in_transfer_transaction.json
@@ -1,0 +1,56 @@
+[
+	{
+		"id": "13847108354832975754",
+		"type": 6,
+		"timestamp": 60991500,
+		"senderPublicKey": "305b4897abc230c1cc9d0aa3bf0c75747bfa42f32f83f5a92348edea528850ad",
+		"senderId": "13155556493249255133L",
+		"recipientId": "",
+		"recipientPublicKey": "",
+		"amount": "500000000",
+		"fee": "10000000",
+		"signature": "be015020b4a89a8cc36ab8ed0047a8138b115f5ce3b1cee35afa5af1e75307a77290bfd07ca7fcc8667cc0c22a83e48bf964d547b5decf662d2624642bd2320e",
+		"signatures": [],
+		"asset": {
+			"inTransfer": {
+				"dappId": "13227044664082109069"
+			}
+		}
+	},
+	{
+		"id": "16982944615812757099",
+		"type": 6,
+		"timestamp": 63895588,
+		"senderPublicKey": "e65b98c217bfcab6d57293056cf4ad78bf45253ab56bc384aff1665cf3611fe9",
+		"senderId": "18237045742439723234L",
+		"recipientId": "",
+		"recipientPublicKey": "",
+		"amount": "1000000000",
+		"fee": "10000000",
+		"signature": "4d5436e731e0f957d6d7eaff2a7bfc13f7a12f963edf88de13419151b74b6664860ddc8ee41588b6200b1018b535f72d3b54e69ccfbf94b6ef1d9b8a8d275205",
+		"signatures": [],
+		"asset": {
+			"inTransfer": {
+				"dappId": "16337394785118081960"
+			}
+		}
+	},
+	{
+		"id": "16286924837183274179",
+		"type": 6,
+		"timestamp": 63898440,
+		"senderPublicKey": "e65b98c217bfcab6d57293056cf4ad78bf45253ab56bc384aff1665cf3611fe9",
+		"senderId": "18237045742439723234L",
+		"recipientId": "",
+		"recipientPublicKey": "",
+		"amount": "1100000000",
+		"fee": "10000000",
+		"signature": "e814fd4924cb1ad94adc788965364ab1e1c9957b03fb177f18866db2ef2254af2b30bd7ffa1b794d239f8990c6d86003be8fb09d3cc4c018979a459e3f82490e",
+		"signatures": [],
+		"asset": {
+			"inTransfer": {
+				"dappId": "16337394785118081960"
+			}
+		}
+	}
+]

--- a/packages/lisk-transactions/src/index.ts
+++ b/packages/lisk-transactions/src/index.ts
@@ -19,7 +19,11 @@ import { registerMultisignature } from './4_register_multisignature_account';
 import { createDapp } from './5_create_dapp';
 import * as constants from './constants';
 import { createSignatureObject } from './create_signature_object';
-import { BaseTransaction, VoteTransaction } from './transactions';
+import {
+	BaseTransaction,
+	InTransferTransaction,
+	VoteTransaction,
+} from './transactions';
 import * as utils from './utils';
 
 // tslint:disable-next-line no-unbound-method
@@ -28,6 +32,7 @@ const castVotes = VoteTransaction.create;
 export {
 	BaseTransaction,
 	VoteTransaction,
+	InTransferTransaction,
 	transfer,
 	registerSecondPassphrase,
 	registerDelegate,

--- a/packages/lisk-transactions/src/transactions/6_in_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/transactions/6_in_transfer_transaction.ts
@@ -1,0 +1,381 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import BigNum from 'browserify-bignum';
+import { TransactionError, TransactionMultiError } from '../errors';
+import { Account, Status, TransactionJSON } from '../transaction_types';
+import { isTypedObjectArrayWithKeys, validator } from '../utils/validation';
+import {
+	Attributes,
+	BaseTransaction,
+	ENTITY_ACCOUNT,
+	ENTITY_TRANSACTION,
+	EntityMap,
+	RequiredState,
+	TransactionResponse,
+} from './base';
+
+export interface InTransferAsset {
+	readonly inTransfer: {
+		readonly dappId: string;
+	};
+}
+
+export interface RequiredInTransferState extends RequiredState {
+	readonly recipient?: Account;
+	readonly dependentState?: {
+		readonly [ENTITY_TRANSACTION]: ReadonlyArray<TransactionJSON>;
+	};
+}
+
+export const inTransferAssetTypeSchema = {
+	type: 'object',
+	required: ['inTransfer'],
+	properties: {
+		inTransfer: {
+			type: 'object',
+			required: ['dappId'],
+			properties: {
+				dappId: {
+					type: 'string',
+				},
+			},
+		},
+	},
+};
+
+export const inTransferAssetFormatSchema = {
+	type: 'object',
+	required: ['inTransfer'],
+	properties: {
+		inTransfer: {
+			type: 'object',
+			required: ['dappId'],
+			properties: {
+				dappId: {
+					type: 'string',
+					format: 'id',
+				},
+			},
+		},
+	},
+};
+
+export class InTransferTransaction extends BaseTransaction {
+	public readonly asset: InTransferAsset;
+
+	public constructor(tx: TransactionJSON) {
+		super(tx);
+		const typeValid = validator.validate(inTransferAssetTypeSchema, tx.asset);
+		const errors = validator.errors
+			? validator.errors.map(
+					error =>
+						new TransactionError(
+							`'${error.dataPath}' ${error.message}`,
+							tx.id,
+							error.dataPath,
+						),
+			  )
+			: [];
+		if (!typeValid) {
+			throw new TransactionMultiError('Invalid field types', tx.id, errors);
+		}
+		this.asset = tx.asset as InTransferAsset;
+	}
+
+	public static fromJSON(tx: TransactionJSON): InTransferTransaction {
+		const transaction = new InTransferTransaction(tx);
+		const { errors, status } = transaction.validateSchema();
+
+		if (status === Status.FAIL && errors.length !== 0) {
+			throw new TransactionMultiError(
+				'Failed to validate schema.',
+				tx.id,
+				errors,
+			);
+		}
+
+		return transaction;
+	}
+
+	protected getAssetBytes(): Buffer {
+		return Buffer.from(this.asset.inTransfer.dappId, 'utf8');
+	}
+
+	public assetToJSON(): object {
+		return {
+			...this.asset,
+		};
+	}
+
+	public getRequiredAttributes(): Attributes {
+		const attr = super.getRequiredAttributes();
+
+		return {
+			...attr,
+			[ENTITY_TRANSACTION]: {
+				id: [this.asset.inTransfer.dappId],
+			},
+		};
+	}
+
+	public verifyAgainstOtherTransactions(
+		_: ReadonlyArray<TransactionJSON>,
+	): TransactionResponse {
+		return {
+			id: this.id,
+			errors: [],
+			status: Status.OK,
+		};
+	}
+
+	public processRequiredState(state: EntityMap): RequiredInTransferState {
+		const accounts = state[ENTITY_ACCOUNT];
+		if (!accounts) {
+			throw new Error('Entity account is required.');
+		}
+		if (
+			!isTypedObjectArrayWithKeys<Account>(accounts, ['address', 'publicKey'])
+		) {
+			throw new Error('Required state does not have valid account type.');
+		}
+
+		const sender = accounts.find(acct => acct.address === this.senderId);
+		if (!sender) {
+			throw new Error('No sender account is found.');
+		}
+
+		// In valid case, transaction should not exist
+		const transactions = state[ENTITY_TRANSACTION];
+		if (!transactions) {
+			throw new Error('Entity transaction is required.');
+		}
+
+		if (
+			!isTypedObjectArrayWithKeys<TransactionJSON>(transactions, [
+				'id',
+				'type',
+				'asset',
+			])
+		) {
+			throw new Error('Required state does not have valid transaction type.');
+		}
+
+		const dependentDappTx = transactions.find(
+			tx => tx.id === this.asset.inTransfer.dappId,
+		);
+
+		const recipient = dependentDappTx
+			? accounts.find(acct => acct.address === dependentDappTx.senderId)
+			: undefined;
+
+		return {
+			sender,
+			recipient,
+			dependentState: {
+				[ENTITY_TRANSACTION]: dependentDappTx ? [dependentDappTx] : [],
+			},
+		};
+	}
+
+	public validateSchema(): TransactionResponse {
+		const { errors: baseErrors, status } = super.validateSchema();
+		const valid = validator.validate(inTransferAssetFormatSchema, this.asset);
+		const errors = [...baseErrors];
+		const assetErrors = validator.errors
+			? validator.errors.map(
+					error =>
+						new TransactionError(
+							`'${error.dataPath}' ${error.message}`,
+							this.id,
+							error.dataPath,
+						),
+			  )
+			: [];
+		errors.push(...assetErrors);
+
+		return {
+			id: this.id,
+			status:
+				status === Status.OK && valid && errors.length === 0
+					? Status.OK
+					: Status.FAIL,
+			errors,
+		};
+	}
+
+	public verify({
+		sender,
+		recipient,
+		dependentState,
+	}: RequiredInTransferState): TransactionResponse {
+		const { errors: baseErrors } = super.apply({ sender });
+		if (!dependentState) {
+			throw new Error(
+				'Dependent state is required for inTransfer transaction.',
+			);
+		}
+		const errors = [...baseErrors];
+		const balance = new BigNum(sender.balance);
+		const fee = new BigNum(this.fee);
+		const amount = new BigNum(this.amount);
+		if (
+			balance
+				.sub(fee)
+				.sub(amount)
+				.lt(0)
+		) {
+			errors.push(
+				new TransactionError(
+					`Sender ${this.senderId} does not have sufficient balance.`,
+					this.id,
+				),
+			);
+		}
+
+		const dependentTransactions = dependentState[ENTITY_TRANSACTION];
+		if (!dependentTransactions) {
+			throw new Error('Entity transaction is required.');
+		}
+		if (
+			!isTypedObjectArrayWithKeys<TransactionJSON>(dependentTransactions, [
+				'id',
+				'senderId',
+			])
+		) {
+			throw new Error('Required state does not have valid transaction type.');
+		}
+
+		const dependentDappTx = dependentTransactions.find(
+			tx => tx.id === this.asset.inTransfer.dappId,
+		);
+
+		if (!dependentDappTx) {
+			errors.push(
+				new TransactionError(
+					`Related transaction ${this.asset.inTransfer.dappId} does not exist.`,
+					this.id,
+				),
+			);
+		}
+
+		if (dependentDappTx && !recipient) {
+			errors.push(
+				new TransactionError(
+					`Dapp owner account ${dependentDappTx.senderId} does not exist.`,
+					this.id,
+				),
+			);
+		}
+
+		return {
+			id: this.id,
+			status: errors.length === 0 ? Status.OK : Status.FAIL,
+			errors,
+		};
+	}
+
+	public apply({
+		sender,
+		recipient,
+	}: RequiredInTransferState): TransactionResponse {
+		const { errors: baseErrors } = super.apply({ sender });
+		const errors = [...baseErrors];
+		// Ignore state from the base transaction
+		const updatedBalance = new BigNum(sender.balance)
+			.sub(this.fee)
+			.sub(this.amount);
+		if (updatedBalance.lt(0)) {
+			errors.push(
+				new TransactionError(
+					`Account does not have enough LSK: ${sender.address}, balance: ${
+						// tslint:disable-next-line no-magic-numbers
+						new BigNum(sender.balance.toString() || '0').div(Math.pow(10, 8))
+					}`,
+					this.id,
+				),
+			);
+		}
+		const updatedSender = { ...sender, balance: updatedBalance.toString() };
+		if (!recipient) {
+			throw new Error('Recipient is required');
+		}
+
+		const updatedRecipientBalance = new BigNum(recipient.balance).add(
+			this.amount,
+		);
+		const updatedRecipient = {
+			...recipient,
+			balance: updatedRecipientBalance.toString(),
+		};
+
+		return {
+			id: this.id,
+			status: errors.length === 0 ? Status.OK : Status.FAIL,
+			errors,
+			state: {
+				sender: updatedSender,
+				recipient: updatedRecipient,
+			},
+		};
+	}
+
+	public undo({
+		sender,
+		recipient,
+	}: RequiredInTransferState): TransactionResponse {
+		const { errors: baseErrors, state } = super.undo({ sender });
+		if (!state) {
+			throw new Error('State is required for undoing transaction.');
+		}
+		const errors = [...baseErrors];
+		// Ignore state from the base transaction
+		const updatedBalance = new BigNum(sender.balance)
+			.add(this.fee)
+			.add(this.amount);
+		if (updatedBalance.lt(0)) {
+			errors.push(
+				new TransactionError(
+					`Account does not have enough LSK: ${sender.address}, balance: ${
+						// tslint:disable-next-line no-magic-numbers
+						new BigNum(sender.balance.toString() || '0').div(Math.pow(10, 8))
+					}`,
+					this.id,
+				),
+			);
+		}
+		const updatedSender = { ...sender, balance: updatedBalance.toString() };
+		if (!recipient) {
+			throw new Error('Recipient is required');
+		}
+
+		const updatedRecipientBalance = new BigNum(recipient.balance).sub(
+			this.amount,
+		);
+		const updatedRecipient = {
+			...recipient,
+			balance: updatedRecipientBalance.toString(),
+		};
+
+		return {
+			id: this.id,
+			status: errors.length === 0 ? Status.OK : Status.FAIL,
+			errors,
+			state: {
+				sender: updatedSender,
+				recipient: updatedRecipient,
+			},
+		};
+	}
+}

--- a/packages/lisk-transactions/src/transactions/6_in_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/transactions/6_in_transfer_transaction.ts
@@ -194,6 +194,29 @@ export class InTransferTransaction extends BaseTransaction {
 		const { errors: baseErrors, status } = super.validateSchema();
 		const valid = validator.validate(inTransferAssetFormatSchema, this.asset);
 		const errors = [...baseErrors];
+		// Per current protocol, this recipientId and recipientPublicKey must be empty
+		if (this.recipientId !== undefined && this.recipientId !== '') {
+			errors.push(
+				new TransactionError(
+					'Recipient id must be empty',
+					this.id,
+					'.recipientId',
+				),
+			);
+		}
+		if (
+			this.recipientPublicKey !== undefined &&
+			this.recipientPublicKey !== ''
+		) {
+			errors.push(
+				new TransactionError(
+					'Recipient public key must be empty',
+					this.id,
+					'.recipientPublicKey',
+				),
+			);
+		}
+
 		if (this.amount.lte(0)) {
 			errors.push(
 				new TransactionError(

--- a/packages/lisk-transactions/src/transactions/6_in_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/transactions/6_in_transfer_transaction.ts
@@ -159,7 +159,6 @@ export class InTransferTransaction extends BaseTransaction {
 			throw new Error('No sender account is found.');
 		}
 
-		// In valid case, transaction should not exist
 		const transactions = state[ENTITY_TRANSACTION];
 		if (!transactions) {
 			throw new Error('Entity transaction is required.');
@@ -175,6 +174,7 @@ export class InTransferTransaction extends BaseTransaction {
 			throw new Error('Required state does not have valid transaction type.');
 		}
 
+		// In valid case, transaction should not exist
 		const dependentDappTx = transactions.find(
 			tx => tx.id === this.asset.inTransfer.dappId,
 		);
@@ -197,7 +197,7 @@ export class InTransferTransaction extends BaseTransaction {
 		const valid = validator.validate(inTransferAssetFormatSchema, this.asset);
 		const errors = [...baseErrors];
 		// Per current protocol, this recipientId and recipientPublicKey must be empty
-		if (this.recipientId !== undefined && this.recipientId !== '') {
+		if (this.recipientId) {
 			errors.push(
 				new TransactionError(
 					'Recipient id must be empty',
@@ -206,10 +206,7 @@ export class InTransferTransaction extends BaseTransaction {
 				),
 			);
 		}
-		if (
-			this.recipientPublicKey !== undefined &&
-			this.recipientPublicKey !== ''
-		) {
+		if (this.recipientPublicKey) {
 			errors.push(
 				new TransactionError(
 					'Recipient public key must be empty',
@@ -222,7 +219,7 @@ export class InTransferTransaction extends BaseTransaction {
 		if (this.amount.lte(0)) {
 			errors.push(
 				new TransactionError(
-					'Amount must be greather than 0',
+					'Amount must be greater than 0',
 					this.id,
 					'.amount',
 				),

--- a/packages/lisk-transactions/src/transactions/6_in_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/transactions/6_in_transfer_transaction.ts
@@ -13,6 +13,7 @@
  *
  */
 import BigNum from 'browserify-bignum';
+import { IN_TRANSFER_FEE } from '../constants';
 import { TransactionError, TransactionMultiError } from '../errors';
 import { Account, Status, TransactionJSON } from '../transaction_types';
 import { convertBeddowsToLSK } from '../utils';
@@ -75,6 +76,7 @@ export const inTransferAssetFormatSchema = {
 
 export class InTransferTransaction extends BaseTransaction {
 	public readonly asset: InTransferAsset;
+	public readonly fee: BigNum = new BigNum(IN_TRANSFER_FEE);
 
 	public constructor(tx: TransactionJSON) {
 		super(tx);
@@ -237,6 +239,16 @@ export class InTransferTransaction extends BaseTransaction {
 			  )
 			: [];
 		errors.push(...assetErrors);
+
+		if (!this.fee.eq(IN_TRANSFER_FEE)) {
+			errors.push(
+				new TransactionError(
+					`Fee must be equal to ${IN_TRANSFER_FEE}`,
+					this.id,
+					'.fee',
+				),
+			);
+		}
 
 		return {
 			id: this.id,

--- a/packages/lisk-transactions/src/transactions/base.ts
+++ b/packages/lisk-transactions/src/transactions/base.ts
@@ -38,6 +38,7 @@ import {
 import { Account, Status, TransactionJSON } from '../transaction_types';
 import {
 	checkTypes,
+	convertBeddowsToLSK,
 	getId,
 	getTimeWithOffset,
 	validator,
@@ -449,10 +450,9 @@ export abstract class BaseTransaction {
 			? []
 			: [
 					new TransactionError(
-						`Account does not have enough LSK: ${sender.address}, balance: ${
-							// tslint:disable-next-line no-magic-numbers
-							new BigNum(sender.balance.toString() || '0').div(Math.pow(10, 8))
-						}`,
+						`Account does not have enough LSK: ${
+							sender.address
+						}, balance: ${convertBeddowsToLSK(sender.balance)}`,
 						this.id,
 					),
 			  ];

--- a/packages/lisk-transactions/src/transactions/base.ts
+++ b/packages/lisk-transactions/src/transactions/base.ts
@@ -77,6 +77,7 @@ export interface RequiredState {
 }
 
 export const ENTITY_ACCOUNT = 'account';
+export const ENTITY_TRANSACTION = 'transaction';
 export interface CreateBaseTransactionInput {
 	readonly passphrase?: string;
 	readonly secondPassphrase?: string;

--- a/packages/lisk-transactions/src/transactions/index.ts
+++ b/packages/lisk-transactions/src/transactions/index.ts
@@ -1,2 +1,3 @@
 export * from './base';
 export * from './3_vote_transaction';
+export * from './6_in_transfer_transaction';

--- a/packages/lisk-transactions/src/utils/validation/schema.ts
+++ b/packages/lisk-transactions/src/utils/validation/schema.ts
@@ -126,8 +126,8 @@ export const baseTransaction = {
 			type: 'string',
 		},
 		recipientPublicKey: {
-			type: ['string', 'null'],
-			format: 'publicKey',
+			type: ['string'],
+			format: 'emptyOrPublicKey',
 		},
 		signature: {
 			type: 'string',

--- a/packages/lisk-transactions/src/utils/validation/validator.ts
+++ b/packages/lisk-transactions/src/utils/validation/validator.ts
@@ -56,6 +56,20 @@ validator.addFormat('nonTransferAmount', validateNonTransferAmount);
 
 validator.addFormat('fee', validateFee);
 
+validator.addFormat('emptyOrPublicKey', data => {
+	if (data === null || data === '') {
+		return true;
+	}
+
+	try {
+		validatePublicKey(data);
+
+		return true;
+	} catch (error) {
+		return false;
+	}
+});
+
 validator.addFormat('publicKey', data => {
 	try {
 		validatePublicKey(data);

--- a/packages/lisk-transactions/test/transactions/6_in_transfer_transaction.ts
+++ b/packages/lisk-transactions/test/transactions/6_in_transfer_transaction.ts
@@ -1,0 +1,555 @@
+/*
+ * Copyright © 2018 Lisk Foundation
+ *
+ * See the LICENSE file at the top-level directory of this distribution
+ * for licensing information.
+ *
+ * Unless otherwise agreed in a custom licensing agreement with the Lisk Foundation,
+ * no part of this software, including this file, may be copied, modified,
+ * propagated, or distributed except according to the terms contained in the
+ * LICENSE file.
+ *
+ * Removal or modification of this copyright notice is prohibited.
+ *
+ */
+import { expect } from 'chai';
+import { SinonStub } from 'sinon';
+import { InTransferTransaction, Attributes } from '../../src/transactions';
+import { validInTransferTransactions, validTransaction } from '../../fixtures';
+import { Status, TransactionJSON } from '../../src/transaction_types';
+import { TransactionError } from '../../src/errors';
+
+describe('InTransfer transaction class', () => {
+	const defaultTransaction = validInTransferTransactions[0];
+
+	let validTestTransaction: InTransferTransaction;
+
+	beforeEach(async () => {
+		validTestTransaction = new InTransferTransaction(defaultTransaction);
+	});
+
+	describe('#constructor', () => {
+		it('should create instance of InTransferTransaction', async () => {
+			expect(validTestTransaction).to.be.instanceOf(InTransferTransaction);
+		});
+
+		it('should set the inTransfer asset', async () => {
+			expect(validTestTransaction.asset.inTransfer).to.be.an('object');
+			expect(validTestTransaction.asset.inTransfer.dappId).to.equal(
+				defaultTransaction.asset.inTransfer.dappId,
+			);
+		});
+
+		it('should throw TransactionMultiError when asset is not string', async () => {
+			const invalidInTransferTransactionData = {
+				...defaultTransaction,
+				asset: {
+					inTransfer: {
+						dappId: 1,
+					},
+				},
+			};
+			expect(
+				() => new InTransferTransaction(invalidInTransferTransactionData),
+			).to.throw('Invalid field types');
+		});
+	});
+
+	describe('#fromJSON', () => {
+		beforeEach(async () => {
+			sandbox.stub(InTransferTransaction.prototype, 'validateSchema').returns({
+				id: validTestTransaction.id,
+				status: Status.OK,
+				errors: [],
+			});
+			validTestTransaction = InTransferTransaction.fromJSON(
+				validInTransferTransactions[1],
+			);
+		});
+
+		it('should create instance of InTransferTransaction', async () => {
+			expect(validTestTransaction).to.be.instanceOf(InTransferTransaction);
+		});
+
+		it('should call validateSchema', async () => {
+			expect(validTestTransaction.validateSchema).to.be.calledOnce;
+		});
+
+		it('should throw an error if validateSchema returns error', async () => {
+			(InTransferTransaction.prototype.validateSchema as SinonStub).returns({
+				status: Status.FAIL,
+				errors: [new TransactionError()],
+			});
+			expect(
+				InTransferTransaction.fromJSON.bind(
+					undefined,
+					validInTransferTransactions[1],
+				),
+			).to.throw('Failed to validate schema.');
+		});
+	});
+
+	describe('#getAssetBytes', () => {
+		it('should return valid buffer', async () => {
+			const assetBytes = (validTestTransaction as any).getAssetBytes();
+			expect(assetBytes).to.eql(
+				Buffer.from(defaultTransaction.asset.inTransfer.dappId, 'utf8'),
+			);
+		});
+	});
+
+	describe('#verifyAgainstOtherTransactions', () => {
+		it('should return status true', async () => {
+			const {
+				errors,
+				status,
+			} = validTestTransaction.verifyAgainstOtherTransactions([
+				validInTransferTransactions[1],
+			] as ReadonlyArray<TransactionJSON>);
+			expect(errors)
+				.to.be.an('array')
+				.of.length(0);
+			expect(status).to.equal(Status.OK);
+		});
+	});
+
+	describe('#getRequiredAttributes', () => {
+		let attribute: Attributes;
+
+		beforeEach(async () => {
+			attribute = validTestTransaction.getRequiredAttributes();
+		});
+
+		it('should return attribute including sender address', async () => {
+			expect(attribute.account.address).to.include(defaultTransaction.senderId);
+		});
+
+		it('should return attribute including dapp id', async () => {
+			expect(attribute.transaction.id).to.include(
+				defaultTransaction.asset.inTransfer.dappId,
+			);
+		});
+	});
+
+	describe('#processRequiredState', () => {
+		it('should return sender, recipient and dependentState.transaction with related dapp transaction', async () => {
+			const validEntity = {
+				account: [
+					{ address: '13155556493249255133L', balance: '10000000000' },
+					{ address: '18237045742439723234L', balance: '0' },
+				],
+				transaction: [
+					{
+						id: '13227044664082109069',
+						type: 5,
+						senderId: '18237045742439723234L',
+					},
+				],
+			};
+			const {
+				sender,
+				recipient,
+				dependentState,
+			} = validTestTransaction.processRequiredState(validEntity);
+			expect(sender.address).to.equal('13155556493249255133L');
+			expect(recipient).not.to.be.empty;
+			expect((recipient as any).address).to.equal('18237045742439723234L');
+			expect((dependentState as any).transaction).not.to.be.empty;
+			expect((dependentState as any).transaction[0]).to.eql(
+				validEntity.transaction[0],
+			);
+		});
+
+		it('should only return sender', async () => {
+			const validEntity = {
+				account: [{ address: '13155556493249255133L', balance: '10000000000' }],
+				transaction: [],
+			};
+			const {
+				sender,
+				recipient,
+				dependentState,
+			} = validTestTransaction.processRequiredState(validEntity);
+			expect(sender.address).to.equal('13155556493249255133L');
+			expect(recipient).to.be.undefined;
+			expect((dependentState as any).transaction).to.be.empty;
+		});
+
+		it('should throw an error when state does not have account key', async () => {
+			expect(
+				validTestTransaction.processRequiredState.bind(
+					validTestTransaction,
+					{},
+				),
+			).to.throw('Entity account is required.');
+		});
+
+		it('should throw an error when account state does not have address and balance', async () => {
+			const invalidEntity = {
+				account: [
+					{ balance: '0' },
+					{
+						address: '1L',
+						publicKey:
+							'30c07dbb72b41e3fda9f29e1a4fc0fce893bb00788515a5e6f50b80312e2f483',
+					},
+				],
+			};
+			expect(
+				validTestTransaction.processRequiredState.bind(
+					validTestTransaction,
+					invalidEntity,
+				),
+			).to.throw('Required state does not have valid account type.');
+		});
+
+		it('should throw an error when account state does not include the sender', async () => {
+			const invalidEntity = {
+				account: [
+					{
+						address: '1L',
+						balance: '0',
+					},
+				],
+			};
+			expect(
+				validTestTransaction.processRequiredState.bind(
+					validTestTransaction,
+					invalidEntity,
+				),
+			).to.throw('No sender account is found.');
+		});
+
+		it('should throw an error when state does not include transaction', async () => {
+			const invalidEntity = {
+				account: [
+					{ address: '13155556493249255133L', balance: '10000000000' },
+					{ address: '18237045742439723234L', balance: '0' },
+				],
+			};
+			expect(
+				validTestTransaction.processRequiredState.bind(
+					validTestTransaction,
+					invalidEntity,
+				),
+			).to.throw('Entity transaction is required.');
+		});
+
+		it('should throw an error when state includes invalid transaction type', async () => {
+			const invalidEntity = {
+				account: [
+					{ address: '13155556493249255133L', balance: '10000000000' },
+					{ address: '18237045742439723234L', balance: '0' },
+				],
+				transaction: [{ id: '13227044664082109069' }],
+			};
+			expect(
+				validTestTransaction.processRequiredState.bind(
+					validTestTransaction,
+					invalidEntity,
+				),
+			).to.throw('Required state does not have valid transaction type.');
+		});
+	});
+
+	describe('#validateSchema', () => {
+		it('should return TransactionResponse with status OK', async () => {
+			const { status } = validTestTransaction.validateSchema();
+			expect(status).to.equal(Status.OK);
+		});
+
+		it('should return TransactionResponse with error when asset includes non id format dappId', async () => {
+			const invalidTransaction = {
+				...defaultTransaction,
+				id: '17748758437863626387',
+				asset: {
+					inTransfer: {
+						dappId: 'id-not-id-format-zzzzz',
+					},
+				},
+			};
+			const transaction = new InTransferTransaction(invalidTransaction);
+			const { status, errors } = transaction.validateSchema();
+			expect(status).to.equal(Status.FAIL);
+			expect(errors).not.to.be.empty;
+			expect(errors[0].dataPath).to.equal('.inTransfer.dappId');
+		});
+
+		it('should return TransactionResponse with error when amount is zero', async () => {
+			const invalidTransaction = {
+				...defaultTransaction,
+				id: '16332529042692216279',
+				amount: '0',
+			};
+			const transaction = new InTransferTransaction(invalidTransaction);
+			const { status, errors } = transaction.validateSchema();
+			expect(status).to.equal(Status.FAIL);
+			expect(errors).not.to.be.empty;
+			expect(errors[0].dataPath).to.equal('.amount');
+		});
+	});
+
+	describe('#verify', () => {
+		const defaultValidSender = {
+			address: '8004805717140184627L',
+			balance: '1000000000',
+			publicKey:
+				'305b4897abc230c1cc9d0aa3bf0c75747bfa42f32f83f5a92348edea528850ad',
+		};
+
+		const defaultValidTxs = [
+			{
+				id: '13227044664082109069',
+				type: 5,
+				senderId: '18237045742439723234L',
+			},
+		];
+
+		const defaultValidRecipient = {
+			address: '18237045742439723234L',
+			balance: '0',
+			publicKey:
+				'e65b98c217bfcab6d57293056cf4ad78bf45253ab56bc384aff1665cf3611fe9',
+		};
+
+		it('should return TransactionResponse with status OK', async () => {
+			const { status, errors } = validTestTransaction.verify({
+				sender: defaultValidSender,
+				recipient: defaultValidRecipient,
+				dependentState: { transaction: defaultValidTxs as any },
+			});
+			expect(status).to.equal(Status.OK);
+			expect(errors).to.be.empty;
+		});
+
+		it('should throw an error when dependent state does not exist', async () => {
+			expect(
+				validTestTransaction.verify.bind(validTestTransaction, {
+					sender: defaultValidSender,
+				}),
+			).to.throw('Dependent state is required for inTransfer transaction.');
+		});
+
+		it('should throw an error when dependent state does include transaction', async () => {
+			expect(
+				validTestTransaction.verify.bind(validTestTransaction, {
+					sender: defaultValidSender,
+					dependentState: {} as any,
+				}),
+			).to.throw('Entity transaction is required.');
+		});
+
+		it('should throw an error when dependent state transaction does not id', async () => {
+			expect(
+				validTestTransaction.verify.bind(validTestTransaction, {
+					sender: defaultValidSender,
+					dependentState: {
+						transaction: [{ senderId: '123L' }],
+					} as any,
+				}),
+			).to.throw('Required state does not have valid transaction type.');
+		});
+
+		it('should throw an error when dependent state transaction does not senderId', async () => {
+			expect(
+				validTestTransaction.verify.bind(validTestTransaction, {
+					sender: defaultValidSender,
+					dependentState: {
+						transaction: [{ id: '16286924837183274179' }],
+					} as any,
+				}),
+			).to.throw('Required state does not have valid transaction type.');
+		});
+
+		it('should return TransactionResponse with error when voted sender account does not have sufficient balance', async () => {
+			const invalidSender = {
+				...defaultValidSender,
+				balance: '0',
+			};
+			const { status, errors } = validTestTransaction.verify({
+				sender: invalidSender,
+				recipient: defaultValidRecipient,
+				dependentState: { transaction: defaultValidTxs as any },
+			});
+			expect(status).to.eql(Status.FAIL);
+			expect(errors).not.to.be.empty;
+			expect(errors[0].message).to.equal(
+				`Account does not have enough LSK: ${invalidSender.address}, balance: ${
+					invalidSender.balance
+				}`,
+			);
+		});
+
+		it('should return TransactionResponse with error when the related dapp transaction does not exist', async () => {
+			const { status, errors } = validTestTransaction.verify({
+				sender: defaultValidSender,
+				dependentState: { transaction: [] },
+			});
+			expect(status).to.eql(Status.FAIL);
+			expect(errors).not.to.be.empty;
+			expect(errors[0].message).to.equal(
+				`Related transaction ${
+					validTestTransaction.asset.inTransfer.dappId
+				} does not exist.`,
+			);
+		});
+
+		it('should return TransactionResponse with error when the recipient of the account is not given', async () => {
+			const { status, errors } = validTestTransaction.verify({
+				sender: defaultValidSender,
+				dependentState: { transaction: defaultValidTxs as any },
+			});
+			expect(status).to.eql(Status.FAIL);
+			expect(errors).not.to.be.empty;
+			expect(errors[0].message).to.equal(
+				`Dapp owner account ${defaultValidTxs[0].senderId} does not exist.`,
+			);
+		});
+	});
+
+	describe('#apply', () => {
+		const defaultValidSender = {
+			address: '8004805717140184627L',
+			balance: '510000000',
+			publicKey:
+				'305b4897abc230c1cc9d0aa3bf0c75747bfa42f32f83f5a92348edea528850ad',
+		};
+
+		const defaultValidRecipient = {
+			address: '18237045742439723234L',
+			balance: '0',
+			publicKey:
+				'e65b98c217bfcab6d57293056cf4ad78bf45253ab56bc384aff1665cf3611fe9',
+		};
+
+		it('should return TransactionResponse with status OK with updated sender and recipient', async () => {
+			const { status, errors } = validTestTransaction.apply({
+				sender: defaultValidSender,
+				recipient: defaultValidRecipient,
+			});
+			expect(status).to.equal(Status.OK);
+			expect(errors).to.be.empty;
+		});
+
+		it('should return TransactionResponse with updated sender and recipient', async () => {
+			const { state } = validTestTransaction.apply({
+				sender: defaultValidSender,
+				recipient: defaultValidRecipient,
+			});
+			expect(state).not.to.be.empty;
+			expect((state as any).sender.balance).to.equal('0');
+			expect((state as any).recipient.balance).to.equal('500000000');
+		});
+
+		it('should throw an error when recipient is not supplied', async () => {
+			expect(
+				validTestTransaction.apply.bind(validTransaction, {
+					sender: defaultValidSender,
+				}),
+			).to.throw('Recipient is required.');
+		});
+
+		it('should return transaction response with error when sender does not have enough balance', async () => {
+			const invalidSender = {
+				...defaultValidSender,
+				balance: '10000000',
+			};
+			const { status, errors } = validTestTransaction.apply({
+				sender: invalidSender,
+				recipient: defaultValidRecipient,
+			});
+			expect(status).to.be.equal(Status.FAIL);
+			expect(errors).not.to.be.empty;
+			expect(errors[0].message).to.equal(
+				`Account does not have enough LSK: ${
+					invalidSender.address
+				}, balance: 0.1.`,
+			);
+		});
+
+		it('should return updated account when sender does not have enough balance', async () => {
+			const invalidSender = {
+				...defaultValidSender,
+				balance: '10000000',
+			};
+			const { state } = validTestTransaction.apply({
+				sender: invalidSender,
+				recipient: defaultValidRecipient,
+			});
+			expect((state as any).sender.balance).to.equal('-500000000');
+		});
+	});
+
+	describe('#undo', () => {
+		const defaultValidSender = {
+			address: '8004805717140184627L',
+			balance: '0',
+			publicKey:
+				'305b4897abc230c1cc9d0aa3bf0c75747bfa42f32f83f5a92348edea528850ad',
+		};
+
+		const defaultValidRecipient = {
+			address: '18237045742439723234L',
+			balance: '500000000',
+			publicKey:
+				'e65b98c217bfcab6d57293056cf4ad78bf45253ab56bc384aff1665cf3611fe9',
+		};
+
+		it('should return TransactionResponse with status OK with updated sender and recipient', async () => {
+			const { status, errors } = validTestTransaction.undo({
+				sender: defaultValidSender,
+				recipient: defaultValidRecipient,
+			});
+			expect(status).to.equal(Status.OK);
+			expect(errors).to.be.empty;
+		});
+
+		it('should return TransactionResponse with updated sender and recipient', async () => {
+			const { state } = validTestTransaction.undo({
+				sender: defaultValidSender,
+				recipient: defaultValidRecipient,
+			});
+			expect(state).not.to.be.empty;
+			expect((state as any).sender.balance).to.equal('510000000');
+			expect((state as any).recipient.balance).to.equal('0');
+		});
+
+		it('should throw an error when recipient is not supplied', async () => {
+			expect(
+				validTestTransaction.undo.bind(validTransaction, {
+					sender: defaultValidSender,
+				}),
+			).to.throw('Recipient is required.');
+		});
+
+		it('should return transaction response with error when sender does not have enough balance', async () => {
+			const invalidRecipient = {
+				...defaultValidRecipient,
+				balance: '0',
+			};
+			const { status, errors } = validTestTransaction.undo({
+				sender: defaultValidSender,
+				recipient: invalidRecipient,
+			});
+			expect(status).to.be.equal(Status.FAIL);
+			expect(errors).not.to.be.empty;
+			expect(errors[0].message).to.equal(
+				`Account does not have enough LSK: ${
+					invalidRecipient.address
+				}, balance: 0.`,
+			);
+		});
+
+		it('should return updated account when sender does not have enough balance', async () => {
+			const invalidRecipient = {
+				...defaultValidRecipient,
+				balance: '0',
+			};
+			const { state } = validTestTransaction.undo({
+				sender: defaultValidSender,
+				recipient: invalidRecipient,
+			});
+			expect((state as any).recipient.balance).to.equal('-500000000');
+		});
+	});
+});

--- a/packages/lisk-transactions/test/transactions/6_in_transfer_transaction.ts
+++ b/packages/lisk-transactions/test/transactions/6_in_transfer_transaction.ts
@@ -275,6 +275,32 @@ describe('InTransfer transaction class', () => {
 			expect(errors[0].dataPath).to.equal('.inTransfer.dappId');
 		});
 
+		it('should return TransactionResponse with error when recipientId is not empty', async () => {
+			const invalidTransaction = {
+				...defaultTransaction,
+				id: '1070575047580588345',
+				recipientId: '13155556493249255133L',
+			};
+			const transaction = new InTransferTransaction(invalidTransaction);
+			const { status, errors } = transaction.validateSchema();
+			expect(status).to.equal(Status.FAIL);
+			expect(errors).not.to.be.empty;
+			expect(errors[0].dataPath).to.equal('.recipientId');
+		});
+
+		it('should return TransactionResponse with error when recipientPublicKey is not empty', async () => {
+			const invalidTransaction = {
+				...defaultTransaction,
+				recipientPublicKey:
+					'305b4897abc230c1cc9d0aa3bf0c75747bfa42f32f83f5a92348edea528850ad',
+			};
+			const transaction = new InTransferTransaction(invalidTransaction);
+			const { status, errors } = transaction.validateSchema();
+			expect(status).to.equal(Status.FAIL);
+			expect(errors).not.to.be.empty;
+			expect(errors[0].dataPath).to.equal('.recipientPublicKey');
+		});
+
 		it('should return TransactionResponse with error when amount is zero', async () => {
 			const invalidTransaction = {
 				...defaultTransaction,


### PR DESCRIPTION
### Description
Adds InTransfer transaction handling.
Since it's currently disabled, we do not have `create` method for this.

### Review checklist

* The PR resolves #888 
* Merge after #976 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
