### PR TITLE
Add receive data and handle response mechanism - Addresses #896

### DIFF
--- a/packages/lisk-p2p/package.json
+++ b/packages/lisk-p2p/package.json
@@ -29,7 +29,7 @@
 		"lint": "tslint --format verbose --project .",
 		"lint:fix": "npm run lint -- --fix",
 		"test": "TS_NODE_PROJECT=./test/tsconfig.json nyc mocha test/{,/**/}/*.ts",
-		"test:integration": "TS_NODE_PROJECT=./test/tsconfig.json nyc mocha test/integration/*.ts",
+		"test:integration": "TS_NODE_PROJECT=./test/tsconfig.json nyc mocha test/integration/*.ts --reporter spec --timeout 3000 --slow 3000",
 		"test:watch": "npm test -- --watch",
 		"test:watch:min": "npm run test:watch -- --reporter=min",
 		"test:node": "npm run build:check",

--- a/packages/lisk-p2p/package.json
+++ b/packages/lisk-p2p/package.json
@@ -29,7 +29,7 @@
 		"lint": "tslint --format verbose --project .",
 		"lint:fix": "npm run lint -- --fix",
 		"test": "TS_NODE_PROJECT=./test/tsconfig.json nyc mocha test/{,/**/}/*.ts",
-		"test:integration": "TS_NODE_PROJECT=./test/tsconfig.json nyc mocha test/integration/*.ts --reporter spec --timeout 3000 --slow 3000",
+		"test:integration": "TS_NODE_PROJECT=./test/tsconfig.json nyc mocha test/integration/*.ts",
 		"test:watch": "npm test -- --watch",
 		"test:watch:min": "npm run test:watch -- --reporter=min",
 		"test:node": "npm run build:check",

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -200,7 +200,6 @@ export class P2P extends EventEmitter {
 				this._isActive = false;
 				resolve();
 			});
-			this._httpServer.close();
 		});
 	}
 
@@ -210,7 +209,6 @@ export class P2P extends EventEmitter {
 				this._isActive = false;
 				resolve();
 			});
-			this._httpServer.close();
 		});
 	}
 

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -251,9 +251,11 @@ export class P2P extends EventEmitter {
 
 	public async start(): Promise<void> {
 		await this._startPeerServer();
+
 		const discoveredPeers = await this._runPeerDiscovery(
 			this._config.seedPeers,
 		);
+
 		// Add all the discovered peers in newPeer list
 		discoveredPeers.forEach((peerInfo: PeerInfo) => {
 			this._newPeers.add(peerInfo);

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -65,7 +65,7 @@ export interface ProtocolPeerInfo {
 	readonly nonce: string;
 	readonly os: string;
 	readonly version: string;
-	readonly wsPort: number;
+	readonly wsPort: string;
 }
 
 // This is a representation of the peer list according to the current protocol.

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -135,11 +135,11 @@ export class Peer extends EventEmitter {
 		return this._id;
 	}
 
-	public set inboundSocket(value: SCServerSocket) {
+	public set inboundSocket(scServerSocket: SCServerSocket) {
 		if (this._inboundSocket) {
 			this._unbindHandlersFromInboundSocket(this._inboundSocket);
 		}
-		this._inboundSocket = value as SCServerSocketUpdated;
+		this._inboundSocket = scServerSocket as SCServerSocketUpdated;
 		this._bindHandlersToInboundSocket(this._inboundSocket);
 	}
 
@@ -147,8 +147,8 @@ export class Peer extends EventEmitter {
 		return this._ipAddress;
 	}
 
-	public set outboundSocket(value: SCClientSocket) {
-		this._outboundSocket = value;
+	public set outboundSocket(scClientSocket: SCClientSocket) {
+		this._outboundSocket = scClientSocket;
 	}
 
 	public get peerInfo(): PeerInfo {
@@ -324,15 +324,15 @@ export class Peer extends EventEmitter {
 		inboundSocket.off(REMOTE_EVENT_MESSAGE, this._handleMessage);
 	}
 
+	// Update peerInfo with the latest values from the remote peer.
 	private _handlePeerInfo(request: ProtocolRPCRequest): void {
-		// Update peerInfo with the latest values from the remote peer.
-		// TODO ASAP: Validate and/or sanitize the request.data as a PeerInfo object.
 		try {
-			const newPeerInfo = sanitizePeerInfo(request.data);
-			// Merge new info with existing info.
+			// Only allow updating the height and version.
+			const { height, version } = sanitizePeerInfo(request.data);
+			const peerInfoChange = { height, version };
 			this._peerInfo = {
 				...this._peerInfo,
-				...newPeerInfo,
+				...peerInfoChange,
 			};
 		} catch (error) {
 			this.emit(EVENT_FAILED_PEER_INFO_UPDATE, error);

--- a/packages/lisk-p2p/test/unit/sanitization.ts
+++ b/packages/lisk-p2p/test/unit/sanitization.ts
@@ -15,11 +15,11 @@
 import { expect } from 'chai';
 import {
 	validatePeerAddress,
-	instantiatePeerFromResponse,
-} from '../../src/response_handler_sanitization';
+	sanitizePeerInfo,
+} from '../../src/sanitization';
 
 describe('response handlers', () => {
-	describe('#instantiatePeerFromResponse', () => {
+	describe('#sanitizePeerInfo', () => {
 		describe('for valid peer response object', () => {
 			const peer: unknown = {
 				ip: '12.23.54.3',
@@ -46,7 +46,7 @@ describe('response handlers', () => {
 			};
 
 			it('should return PeerInfo object', () => {
-				return expect(instantiatePeerFromResponse(peer))
+				return expect(sanitizePeerInfo(peer))
 					.to.be.an('object')
 					.include({
 						ipAddress: '12.23.54.3',
@@ -58,7 +58,7 @@ describe('response handlers', () => {
 			});
 
 			it('should return PeerInfo object with height value set to 0', () => {
-				return expect(instantiatePeerFromResponse(peerWithInvalidHeightValue))
+				return expect(sanitizePeerInfo(peerWithInvalidHeightValue))
 					.to.be.an('object')
 					.include({
 						ipAddress: '12.23.54.3',
@@ -70,7 +70,7 @@ describe('response handlers', () => {
 			});
 
 			it('should return PeerInfo and instance of Peer sets blank for invalid value of os', () => {
-				return expect(instantiatePeerFromResponse(peerWithInvalidOsValue))
+				return expect(sanitizePeerInfo(peerWithInvalidOsValue))
 					.to.be.an('object')
 					.include({
 						ipAddress: '12.23.54.3',
@@ -87,7 +87,7 @@ describe('response handlers', () => {
 				const peerInvalid: unknown = null;
 
 				return expect(
-					instantiatePeerFromResponse.bind(null, peerInvalid),
+					sanitizePeerInfo.bind(null, peerInvalid),
 				).to.throw('Invalid peer object');
 			});
 
@@ -100,7 +100,7 @@ describe('response handlers', () => {
 				};
 
 				return expect(
-					instantiatePeerFromResponse.bind(null, peerInvalid),
+					sanitizePeerInfo.bind(null, peerInvalid),
 				).to.throw('Invalid peer ip or port');
 			});
 
@@ -114,7 +114,7 @@ describe('response handlers', () => {
 				};
 
 				return expect(
-					instantiatePeerFromResponse.bind(null, peerInvalid),
+					sanitizePeerInfo.bind(null, peerInvalid),
 				).to.throw('Invalid peer version');
 			});
 		});


### PR DESCRIPTION
### What was the problem?

We need to be more structured with event handling.

### How did I fix it?

- Bind event handlers in a single place and unbind events handlers from a single place.
- Improved handling of inbound PeerInfo (peer headers).
- Renamed the sanitization file and some of the methods and variables inside it to be more generic (since its also used to check the payload of `updateMyself`; not just responses).

### How to test it?

Integration tests.

### Review checklist

* The PR addresses #896
