### PR TITLE
Add separate functions to drop inbound and outbound connections -Closes #1005

### DIFF
--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -214,6 +214,19 @@ export class Peer extends EventEmitter {
 		}
 	}
 
+	public dropInboundConnection(code: number = 1000, reason?: string): void {
+		if (this._inboundSocket) {
+			this._inboundSocket.destroy(code, reason);
+			this._stopListeningForRPCs(this._inboundSocket);
+		}
+	}
+
+	public dropOutboundConnection(code: number = 1000, reason?: string): void {
+		if (this._outboundSocket) {
+			this._outboundSocket.destroy(code, reason);
+		}
+	}
+
 	public send<T>(packet: P2PMessagePacket<T>): void {
 		if (!this._outboundSocket) {
 			this._outboundSocket = this._createOutboundSocket();

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -205,13 +205,8 @@ export class Peer extends EventEmitter {
 	}
 
 	public disconnect(code: number = 1000, reason?: string): void {
-		if (this._inboundSocket) {
-			this._inboundSocket.destroy(code, reason);
-			this._stopListeningForRPCs(this._inboundSocket);
-		}
-		if (this._outboundSocket) {
-			this._outboundSocket.destroy(code, reason);
-		}
+		this.dropInboundConnection(code, reason);
+		this.dropOutboundConnection(code, reason);
 	}
 
 	public dropInboundConnection(code: number = 1000, reason?: string): void {


### PR DESCRIPTION
### Description

Add function to drop inbound and outbound connections of a peer to explicitly drop either connection

### Review checklist

* The PR resolves #1005 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
