### PR TITLE
Remove local definition of socketcluster-server for close() method - Closes#1010

### DIFF
--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -34,12 +34,6 @@ import {
 	P2PResponsePacket,
 } from './p2p_types';
 
-type SCServerCloseCallback = () => void;
-
-type SCServerUpdated = {
-	readonly close: (sCServerCloseCallback: SCServerCloseCallback) => void;
-} & SCServer;
-
 import { PeerPool } from './peer_pool';
 
 export const EVENT_NEW_INBOUND_PEER = 'newInboundPeer';
@@ -57,7 +51,7 @@ export class P2P extends EventEmitter {
 
 	private _nodeInfo: P2PNodeInfo;
 	private readonly _peerPool: PeerPool;
-	private readonly _scServer: SCServerUpdated;
+	private readonly _scServer: SCServer;
 
 	public constructor(config: P2PConfig) {
 		super();
@@ -74,7 +68,7 @@ export class P2P extends EventEmitter {
 
 		this._peerPool = new PeerPool();
 		this._httpServer = http.createServer();
-		this._scServer = attach(this._httpServer) as SCServerUpdated;
+		this._scServer = attach(this._httpServer);
 	}
 
 	public get isActive(): boolean {


### PR DESCRIPTION
### Description

Since complete definition of `SCServer` is available on [@types/socketcluster-server](https://www.npmjs.com/package/@types/socketcluster-server) so remove the local definition of method `close()`

### Review checklist

* The PR resolves #1010 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
