### PR TITLE
Add receive data and handle response mechanism - Closes #896 and #981

### DIFF
--- a/packages/lisk-p2p/src/disconnect_status_codes.ts
+++ b/packages/lisk-p2p/src/disconnect_status_codes.ts
@@ -1,0 +1,5 @@
+export const INVALID_CONNECTION_URL_CODE = 4501;
+export const INVALID_CONNECTION_URL_REASON = 'Peer did not provide a valid URL as part of the WebSocket connection';
+
+export const INVALID_CONNECTION_QUERY_CODE = 4502;
+export const INVALID_CONNECTION_QUERY_REASON = 'Peer did not provide valid query parameters as part of the WebSocket connection';

--- a/packages/lisk-p2p/src/errors.ts
+++ b/packages/lisk-p2p/src/errors.ts
@@ -56,6 +56,13 @@ export class InvalidRPCResponse extends VError {
 	}
 }
 
+export class RPCResponseAlreadySentError extends VError {
+	public constructor(message: string) {
+		super(message);
+		this.name = 'ResponseAlreadySentError';
+	}
+}
+
 export class InvalidPeer extends VError {
 	public constructor(message: string) {
 		super(message);

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -16,13 +16,20 @@
 import { EventEmitter } from 'events';
 import http, { Server } from 'http';
 import { platform } from 'os';
-import querystring from 'querystring';
+import url from 'url';
 import { attach, SCServer, SCServerSocket } from 'socketcluster-server';
 
 import { RequestFailError } from './errors';
 import { ConnectionState, Peer, PeerInfo } from './peer';
 import { discoverPeers } from './peer_discovery';
 import { PeerOptions, selectForConnection } from './peer_selection';
+
+import {
+	INVALID_CONNECTION_URL_CODE,
+	INVALID_CONNECTION_URL_REASON,
+	INVALID_CONNECTION_QUERY_CODE,
+	INVALID_CONNECTION_QUERY_REASON,
+} from './disconnect_status_codes';
 
 import {
 	P2PConfig,
@@ -139,15 +146,22 @@ export class P2P extends EventEmitter {
 			(socket: SCServerSocket): void => {
 				if (!socket.request.url) {
 					super.emit(EVENT_FAILED_TO_ADD_INBOUND_PEER);
-
+					socket.disconnect(
+						INVALID_CONNECTION_URL_CODE,
+						INVALID_CONNECTION_URL_REASON,
+					);
 					return;
 				}
-				const queryObject = querystring.parse(socket.request.url);
+				const queryObject = url.parse(socket.request.url, true).query;
 				if (
 					typeof queryObject.wsPort !== 'string' ||
 					typeof queryObject.os !== 'string' ||
 					typeof queryObject.version !== 'string'
 				) {
+					socket.disconnect(
+						INVALID_CONNECTION_QUERY_CODE,
+						INVALID_CONNECTION_QUERY_REASON,
+					);
 					super.emit(EVENT_FAILED_TO_ADD_INBOUND_PEER);
 				} else {
 					const wsPort: number = parseInt(queryObject.wsPort, BASE_10_RADIX);
@@ -229,6 +243,7 @@ export class P2P extends EventEmitter {
 	): Promise<ReadonlyArray<PeerInfo>> {
 		const peersObjectList = peers.map((peerInfo: PeerInfo) => {
 			const peer = new Peer(peerInfo);
+			peer.applyNodeInfo(this._nodeInfo);
 			if (!this._newPeers.has(peerInfo) && !this._triedPeers.has(peerInfo)) {
 				this._newPeers.add(peerInfo);
 				this._peerPool.addPeer(peer);
@@ -257,7 +272,7 @@ export class P2P extends EventEmitter {
 	}
 
 	public async stop(): Promise<void> {
-		this._peerPool.disconnectAllPeers();
+		this._peerPool.removeAllPeers();
 		await this._stopPeerServer();
 	}
 }

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -16,8 +16,8 @@
 import { EventEmitter } from 'events';
 import http, { Server } from 'http';
 import { platform } from 'os';
-import url from 'url';
 import { attach, SCServer, SCServerSocket } from 'socketcluster-server';
+import url from 'url';
 
 import { RequestFailError } from './errors';
 import { ConnectionState, Peer, PeerInfo } from './peer';
@@ -25,10 +25,10 @@ import { discoverPeers } from './peer_discovery';
 import { PeerOptions, selectForConnection } from './peer_selection';
 
 import {
-	INVALID_CONNECTION_URL_CODE,
-	INVALID_CONNECTION_URL_REASON,
 	INVALID_CONNECTION_QUERY_CODE,
 	INVALID_CONNECTION_QUERY_REASON,
+	INVALID_CONNECTION_URL_CODE,
+	INVALID_CONNECTION_URL_REASON,
 } from './disconnect_status_codes';
 
 import {
@@ -41,7 +41,16 @@ import {
 	P2PResponsePacket,
 } from './p2p_types';
 
-import { PeerPool } from './peer_pool';
+import { P2PRequest } from './p2p_request';
+export { P2PRequest };
+
+import {
+	EVENT_MESSAGE_RECEIVED,
+	EVENT_REQUEST_RECEIVED,
+	PeerPool,
+} from './peer_pool';
+
+export { EVENT_REQUEST_RECEIVED, EVENT_MESSAGE_RECEIVED };
 
 export const EVENT_NEW_INBOUND_PEER = 'newInboundPeer';
 export const EVENT_FAILED_TO_ADD_INBOUND_PEER = 'failedToAddInboundPeer';
@@ -60,6 +69,9 @@ export class P2P extends EventEmitter {
 	private readonly _peerPool: PeerPool;
 	private readonly _scServer: SCServer;
 
+	private readonly _handlePeerPoolRPC: (request: P2PRequest) => void;
+	private readonly _handlePeerPoolMessage: (message: P2PMessagePacket) => void;
+
 	public constructor(config: P2PConfig) {
 		super();
 		this._config = config;
@@ -73,9 +85,23 @@ export class P2P extends EventEmitter {
 		this._newPeers = new Set();
 		this._triedPeers = new Set();
 
-		this._peerPool = new PeerPool();
 		this._httpServer = http.createServer();
 		this._scServer = attach(this._httpServer);
+
+		// This needs to be an arrow function so that it can be used as a listener.
+		this._handlePeerPoolRPC = (request: P2PRequest) => {
+			// Re-emit the request for external use.
+			this.emit(EVENT_REQUEST_RECEIVED, request);
+		};
+
+		// This needs to be an arrow function so that it can be used as a listener.
+		this._handlePeerPoolMessage = (message: P2PMessagePacket) => {
+			// Re-emit the message for external use.
+			this.emit(EVENT_MESSAGE_RECEIVED, message);
+		};
+
+		this._peerPool = new PeerPool();
+		this._bindHandlersToPeerPool(this._peerPool);
 	}
 
 	public get isActive(): boolean {
@@ -111,9 +137,7 @@ export class P2P extends EventEmitter {
 		};
 	}
 
-	public async request<T>(
-		packet: P2PRequestPacket<T>,
-	): Promise<P2PResponsePacket> {
+	public async request(packet: P2PRequestPacket): Promise<P2PResponsePacket> {
 		const peerSelectionParams: PeerOptions = {
 			lastBlockHeight: this._nodeInfo.height,
 		};
@@ -129,7 +153,7 @@ export class P2P extends EventEmitter {
 		return response;
 	}
 
-	public send<T>(message: P2PMessagePacket<T>): void {
+	public send(message: P2PMessagePacket): void {
 		const peerSelectionParams: PeerOptions = {
 			lastBlockHeight: this._nodeInfo.height,
 		};
@@ -150,6 +174,7 @@ export class P2P extends EventEmitter {
 						INVALID_CONNECTION_URL_CODE,
 						INVALID_CONNECTION_URL_REASON,
 					);
+
 					return;
 				}
 				const queryObject = url.parse(socket.request.url, true).query;
@@ -274,5 +299,10 @@ export class P2P extends EventEmitter {
 	public async stop(): Promise<void> {
 		this._peerPool.removeAllPeers();
 		await this._stopPeerServer();
+	}
+
+	private _bindHandlersToPeerPool(peerPool: PeerPool): void {
+		peerPool.on(EVENT_REQUEST_RECEIVED, this._handlePeerPoolRPC);
+		peerPool.on(EVENT_MESSAGE_RECEIVED, this._handlePeerPoolMessage);
 	}
 }

--- a/packages/lisk-p2p/src/p2p_request.ts
+++ b/packages/lisk-p2p/src/p2p_request.ts
@@ -1,0 +1,47 @@
+import { RPCResponseAlreadySentError } from './errors';
+
+export class P2PRequest {
+    private readonly _procedure: string;
+    private readonly _data: unknown;
+    private readonly _respondCallback: (responseError?: Error, responseData?: unknown) => void;
+    private _wasResponseSent: boolean;
+
+    public constructor(
+        procedure: string,
+        data: unknown,
+        respondCallback: (responseError?: Error, responseData?: unknown) => void,
+    ) {
+        this._procedure = procedure;
+        this._data = data;
+        this._respondCallback = (responseError?: Error, responseData?: unknown) => {
+            if (this._wasResponseSent) {
+                throw new RPCResponseAlreadySentError(
+                    'A response has already been sent for this request'
+                );
+            }
+            this._wasResponseSent = true;
+            respondCallback(responseError, responseData);
+        };
+        this._wasResponseSent = false;
+    }
+
+    public get procedure(): string {
+        return this._procedure;
+    }
+
+    public get data(): unknown {
+        return this._data;
+    }
+
+    public get wasResponseSent(): boolean {
+        return this._wasResponseSent;
+    }
+
+    public end(responseData?: unknown): void {
+        this._respondCallback(undefined, responseData);
+    }
+
+    public error(responseError: Error): void {
+        this._respondCallback(responseError);
+    }
+}

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -16,8 +16,8 @@
 
 import { PeerInfo } from './peer';
 
-export interface P2PRequestPacket<T> {
-	readonly params?: T;
+export interface P2PRequestPacket {
+	readonly data?: unknown;
 	readonly procedure: string;
 }
 
@@ -25,8 +25,8 @@ export interface P2PResponsePacket {
 	readonly data: unknown;
 }
 
-export interface P2PMessagePacket<T> {
-	readonly data: T;
+export interface P2PMessagePacket {
+	readonly data?: unknown;
 	readonly event: string;
 }
 
@@ -76,14 +76,14 @@ export interface ProtocolPeerList {
 }
 
 // TODO later: Switch to LIP protocol format.
-export interface ProtocolRPCRequest {
+export interface ProtocolRPCRequestPacket {
 	readonly data: unknown;
 	readonly procedure: string;
 	readonly type: string;
 }
 
 // TODO later: Switch to LIP protocol format.
-export interface ProtocolMessage {
+export interface ProtocolMessagePacket {
 	readonly data: unknown;
 	readonly event: string;
 }

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -14,17 +14,19 @@
  */
 
 import { EventEmitter } from 'events';
-import { RPCResponseError } from './errors';
 import querystring from 'querystring';
+import { RPCResponseError } from './errors';
 
 import {
 	P2PMessagePacket,
 	P2PNodeInfo,
 	P2PRequestPacket,
 	P2PResponsePacket,
-	ProtocolMessage,
-	ProtocolRPCRequest,
+	ProtocolMessagePacket,
+	ProtocolRPCRequestPacket,
 } from './p2p_types';
+
+import { P2PRequest } from './p2p_request';
 
 import socketClusterClient, { SCClientSocket } from 'socketcluster-client';
 import { SCServerSocket } from 'socketcluster-server';
@@ -45,6 +47,7 @@ export const REMOTE_EVENT_RPC_REQUEST = 'rpc-request';
 export const REMOTE_EVENT_MESSAGE = 'remote-message';
 
 export const REMOTE_RPC_NODE_INFO = 'updateMyself';
+export const REMOTE_RPC_GET_ALL_PEERS_LIST = 'list';
 
 type SCServerSocketUpdated = {
 	destroy(code?: number, data?: string | object): void;
@@ -79,8 +82,11 @@ export class Peer extends EventEmitter {
 	private _nodeInfo: P2PNodeInfo | undefined;
 	private _inboundSocket: SCServerSocketUpdated | undefined;
 	private _outboundSocket: SCClientSocket | undefined;
-	private readonly _handleRPC: (packet: unknown, respond: any) => void;
-	private readonly _handleMessage: (packet: unknown) => void;
+	private readonly _handleRawRPC: (
+		packet: unknown,
+		respond: (responseError?: Error, responseData?: unknown) => void,
+	) => void;
+	private readonly _handleRawMessage: (packet: unknown) => void;
 
 	public constructor(peerInfo: PeerInfo, inboundSocket?: SCServerSocket) {
 		super();
@@ -95,36 +101,50 @@ export class Peer extends EventEmitter {
 		this._height = peerInfo.height ? peerInfo.height : 0;
 
 		// This needs to be an arrow function so that it can be used as a listener.
-		this._handleRPC = (packet: unknown, respond: any) => {
+		this._handleRawRPC = (
+			packet: unknown,
+			respond: (responseError?: Error, responseData?: unknown) => void,
+		) => {
 			// TODO later: Switch to LIP protocol format.
 			// TODO ASAP: Move validation/sanitization to sanitization.ts with other validation logic.
-			const request = packet as ProtocolRPCRequest;
-			if (!request || typeof request.procedure !== 'string') {
-				this.emit(EVENT_INVALID_REQUEST_RECEIVED, request);
+			const rawRequest = packet as ProtocolRPCRequestPacket; // TODO 2
+
+			if (!rawRequest || typeof rawRequest.procedure !== 'string') {
+				this.emit(EVENT_INVALID_REQUEST_RECEIVED, rawRequest);
 
 				return;
 			}
+			const request = new P2PRequest(
+				rawRequest.procedure,
+				rawRequest.data,
+				respond,
+			);
+
 			if (
 				request.procedure === REMOTE_RPC_NODE_INFO &&
 				typeof request.data === 'object'
 			) {
-				// Internal handling of request to extract the PeerInfo.
-				this._handlePeerInfo(request, respond);
+				// The Peer has the necessary information to handle this request on its own.
+				this._handlePeerInfo(request);
 			}
-			// Emit request for external use.
+
+			// Re-emit the request to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_REQUEST_RECEIVED, request);
 		};
 
 		// This needs to be an arrow function so that it can be used as a listener.
-		this._handleMessage = (packet: unknown) => {
+		this._handleRawMessage = (packet: unknown) => {
 			// TODO later: Switch to LIP protocol format.
 			// TODO ASAP: Move validation/sanitization to sanitization.ts with other validation logic.
-			const message = packet as ProtocolMessage;
-			if (!message || typeof message.event !== 'string') {
-				this.emit(EVENT_INVALID_MESSAGE_RECEIVED, message);
+			const rawMessage = packet as ProtocolMessagePacket;
+			if (!rawMessage || typeof rawMessage.event !== 'string') {
+				this.emit(EVENT_INVALID_MESSAGE_RECEIVED, rawMessage);
 
 				return;
 			}
+			const message = rawMessage as P2PMessagePacket;
+
+			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_MESSAGE_RECEIVED, message);
 		};
 	}
@@ -189,7 +209,7 @@ export class Peer extends EventEmitter {
 	 */
 	public applyNodeInfo(nodeInfo: P2PNodeInfo): void {
 		this._nodeInfo = nodeInfo;
-		this.send<P2PNodeInfo>({
+		this.send({
 			event: REMOTE_RPC_NODE_INFO,
 			data: nodeInfo,
 		});
@@ -225,7 +245,7 @@ export class Peer extends EventEmitter {
 		}
 	}
 
-	public send<T>(packet: P2PMessagePacket<T>): void {
+	public send(packet: P2PMessagePacket): void {
 		if (!this._outboundSocket) {
 			this._outboundSocket = this._createOutboundSocket();
 		}
@@ -234,9 +254,7 @@ export class Peer extends EventEmitter {
 		});
 	}
 
-	public async request<T>(
-		packet: P2PRequestPacket<T>,
-	): Promise<P2PResponsePacket> {
+	public async request(packet: P2PRequestPacket): Promise<P2PResponsePacket> {
 		return new Promise<P2PResponsePacket>(
 			(
 				resolve: (result: P2PResponsePacket) => void,
@@ -250,7 +268,7 @@ export class Peer extends EventEmitter {
 					{
 						type: '/RPCRequest',
 						procedure: packet.procedure,
-						data: packet.params,
+						data: packet.data,
 					},
 					(err: Error | undefined, responseData: unknown) => {
 						if (err) {
@@ -277,7 +295,7 @@ export class Peer extends EventEmitter {
 
 	public async fetchPeers(): Promise<ReadonlyArray<PeerInfo>> {
 		try {
-			const response: P2PResponsePacket = await this.request<void>({
+			const response: P2PResponsePacket = await this.request({
 				procedure: REMOTE_RPC_GET_ALL_PEERS_LIST,
 			});
 
@@ -329,19 +347,19 @@ export class Peer extends EventEmitter {
 
 	// All event handlers for the inbound socket should be bound in this method.
 	private _bindHandlersToInboundSocket(inboundSocket: SCServerSocket): void {
-		inboundSocket.on(REMOTE_EVENT_RPC_REQUEST, this._handleRPC);
-		inboundSocket.on(REMOTE_EVENT_MESSAGE, this._handleMessage);
+		inboundSocket.on(REMOTE_EVENT_RPC_REQUEST, this._handleRawRPC);
+		inboundSocket.on(REMOTE_EVENT_MESSAGE, this._handleRawMessage);
 	}
 
 	// All event handlers for the inbound socket should be unbound in this method.
 	private _unbindHandlersFromInboundSocket(
 		inboundSocket: SCServerSocket,
 	): void {
-		inboundSocket.off(REMOTE_EVENT_RPC_REQUEST, this._handleRPC);
-		inboundSocket.off(REMOTE_EVENT_MESSAGE, this._handleMessage);
+		inboundSocket.off(REMOTE_EVENT_RPC_REQUEST, this._handleRawRPC);
+		inboundSocket.off(REMOTE_EVENT_MESSAGE, this._handleRawMessage);
 	}
 
-	private _handlePeerInfo(request: ProtocolRPCRequest, respond: any): void {
+	private _handlePeerInfo(request: P2PRequest): void {
 		// Update peerInfo with the latest values from the remote peer.
 		// TODO ASAP: Validate and/or sanitize the request.data as a PeerInfo object.
 		try {
@@ -354,11 +372,12 @@ export class Peer extends EventEmitter {
 			};
 		} catch (error) {
 			this.emit(EVENT_FAILED_PEER_INFO_UPDATE, error);
-			respond(error);
+			request.error(error);
+
 			return;
 		}
 
 		this.emit(EVENT_UPDATED_PEER_INFO, this._peerInfo);
-		respond();
+		request.end();
 	}
 }

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -125,7 +125,10 @@ export class Peer extends EventEmitter {
 				typeof request.data === 'object'
 			) {
 				// The Peer has the necessary information to handle this request on its own.
+				// This request doesn't need to propagate to its parent class.
 				this._handlePeerInfo(request);
+
+				return;
 			}
 
 			// Re-emit the request to allow it to bubble up the class hierarchy.

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -15,6 +15,7 @@
 
 import { EventEmitter } from 'events';
 import { RPCResponseError } from './errors';
+import querystring from 'querystring';
 
 import {
 	P2PMessagePacket,
@@ -32,17 +33,18 @@ import { sanitizePeerInfo, sanitizePeerInfoList } from './sanitization';
 // Local emitted events.
 export const EVENT_UPDATED_PEER_INFO = 'updatedPeerInfo';
 export const EVENT_FAILED_PEER_INFO_UPDATE = 'failedPeerInfoUpdate';
-export const EVENT_INVALID_REQUEST_RECEIVED = 'invalidRequestReceived';
 export const EVENT_REQUEST_RECEIVED = 'requestReceived';
+export const EVENT_INVALID_REQUEST_RECEIVED = 'invalidRequestReceived';
+export const EVENT_MESSAGE_RECEIVED = 'messageReceived';
 export const EVENT_INVALID_MESSAGE_RECEIVED = 'invalidMessageReceived';
-export const EVENT_MESSAGE_RECEIVED = 'requestReceived';
 export const EVENT_CONNECT_OUTBOUND = 'connectOutbound';
+export const EVENT_DISCONNECT_OUTBOUND = 'disconnectOutbound';
 
 // Remote event or RPC names sent to or received from peers.
 export const REMOTE_EVENT_RPC_REQUEST = 'rpc-request';
-export const REMOTE_EVENT_MESSAGE = 'message';
-export const REMOTE_EVENT_SEND_NODE_INFO = 'updateMyself';
-export const REMOTE_RPC_GET_ALL_PEERS_LIST = 'list';
+export const REMOTE_EVENT_MESSAGE = 'remote-message';
+
+export const REMOTE_RPC_NODE_INFO = 'updateMyself';
 
 type SCServerSocketUpdated = {
 	destroy(code?: number, data?: string | object): void;
@@ -77,7 +79,7 @@ export class Peer extends EventEmitter {
 	private _nodeInfo: P2PNodeInfo | undefined;
 	private _inboundSocket: SCServerSocketUpdated | undefined;
 	private _outboundSocket: SCClientSocket | undefined;
-	private readonly _handleRPC: (packet: unknown) => void;
+	private readonly _handleRPC: (packet: unknown, respond: any) => void;
 	private readonly _handleMessage: (packet: unknown) => void;
 
 	public constructor(peerInfo: PeerInfo, inboundSocket?: SCServerSocket) {
@@ -93,7 +95,7 @@ export class Peer extends EventEmitter {
 		this._height = peerInfo.height ? peerInfo.height : 0;
 
 		// This needs to be an arrow function so that it can be used as a listener.
-		this._handleRPC = (packet: unknown) => {
+		this._handleRPC = (packet: unknown, respond: any) => {
 			// TODO later: Switch to LIP protocol format.
 			// TODO ASAP: Move validation/sanitization to sanitization.ts with other validation logic.
 			const request = packet as ProtocolRPCRequest;
@@ -103,11 +105,11 @@ export class Peer extends EventEmitter {
 				return;
 			}
 			if (
-				request.procedure === REMOTE_EVENT_SEND_NODE_INFO &&
+				request.procedure === REMOTE_RPC_NODE_INFO &&
 				typeof request.data === 'object'
 			) {
 				// Internal handling of request to extract the PeerInfo.
-				this._handlePeerInfo(request);
+				this._handlePeerInfo(request, respond);
 			}
 			// Emit request for external use.
 			this.emit(EVENT_REQUEST_RECEIVED, request);
@@ -188,7 +190,7 @@ export class Peer extends EventEmitter {
 	public applyNodeInfo(nodeInfo: P2PNodeInfo): void {
 		this._nodeInfo = nodeInfo;
 		this.send<P2PNodeInfo>({
-			event: REMOTE_EVENT_SEND_NODE_INFO,
+			event: REMOTE_RPC_NODE_INFO,
 			data: nodeInfo,
 		});
 	}
@@ -294,7 +296,7 @@ export class Peer extends EventEmitter {
 		const outboundSocket = socketClusterClient.create({
 			hostname: this._ipAddress,
 			port: this._wsPort,
-			query: JSON.stringify(this._nodeInfo),
+			query: querystring.stringify(this._nodeInfo),
 			autoConnect: false,
 		});
 
@@ -307,6 +309,13 @@ export class Peer extends EventEmitter {
 	private _bindHandlersToOutboundSocket(outboundSocket: SCClientSocket): void {
 		outboundSocket.on('connect', () => {
 			this.emit(EVENT_CONNECT_OUTBOUND);
+		});
+
+		outboundSocket.on('close', (code, reason) => {
+			this.emit(EVENT_DISCONNECT_OUTBOUND, {
+				code,
+				reason,
+			});
 		});
 	}
 
@@ -332,8 +341,9 @@ export class Peer extends EventEmitter {
 		inboundSocket.off(REMOTE_EVENT_MESSAGE, this._handleMessage);
 	}
 
-	// Update peerInfo with the latest values from the remote peer.
-	private _handlePeerInfo(request: ProtocolRPCRequest): void {
+	private _handlePeerInfo(request: ProtocolRPCRequest, respond: any): void {
+		// Update peerInfo with the latest values from the remote peer.
+		// TODO ASAP: Validate and/or sanitize the request.data as a PeerInfo object.
 		try {
 			// Only allow updating the height and version.
 			const { height, version } = sanitizePeerInfo(request.data);
@@ -344,10 +354,11 @@ export class Peer extends EventEmitter {
 			};
 		} catch (error) {
 			this.emit(EVENT_FAILED_PEER_INFO_UPDATE, error);
-
+			respond(error);
 			return;
 		}
 
 		this.emit(EVENT_UPDATED_PEER_INFO, this._peerInfo);
+		respond();
 	}
 }

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -19,15 +19,48 @@
  */
 
 import { EventEmitter } from 'events';
-import { Peer, PeerInfo } from './peer';
+
+import {
+	Peer,
+	PeerInfo,
+	EVENT_REQUEST_RECEIVED,
+	EVENT_MESSAGE_RECEIVED,
+	REMOTE_EVENT_RPC_REQUEST,
+	REMOTE_EVENT_MESSAGE,
+} from './peer';
+
 import { PeerOptions, selectPeers } from './peer_selection';
+
+import { ProtocolMessage, ProtocolRPCRequest } from './p2p_types';
+
+export const REMOTE_RPC_GET_ALL_PEERS_LIST = 'list';
 
 export class PeerPool extends EventEmitter {
 	private readonly _peerMap: Map<string, Peer>;
+	private readonly _handleRPC: (
+		request: ProtocolRPCRequest,
+		respond: any,
+	) => void;
+	private readonly _handleMessage: (message: ProtocolMessage) => void;
 
 	public constructor() {
 		super();
 		this._peerMap = new Map();
+
+		// This needs to be an arrow function so that it can be used as a listener.
+		this._handleRPC = (request: ProtocolRPCRequest, respond: any) => {
+			// TODO 2: ^ Use different type for request instead of ProtocolRPCRequest
+			if (request.procedure === REMOTE_RPC_GET_ALL_PEERS_LIST) {
+				this._handleGetAllPeersRequest(request, respond); // TODO 2
+			}
+			// Emit request for external use.
+			this.emit(EVENT_REQUEST_RECEIVED, request);
+		};
+
+		// This needs to be an arrow function so that it can be used as a listener.
+		this._handleMessage = (message: ProtocolMessage) => {
+			this.emit(EVENT_MESSAGE_RECEIVED, message);
+		};
 	}
 
 	public selectPeers(
@@ -45,11 +78,13 @@ export class PeerPool extends EventEmitter {
 
 	public addPeer(peer: Peer): void {
 		this._peerMap.set(peer.id, peer);
+		this._bindHandlersToPeer(peer);
+		peer.connect();
 	}
 
-	public disconnectAllPeers(): void {
+	public removeAllPeers(): void {
 		this._peerMap.forEach((peer: Peer) => {
-			peer.disconnect();
+			this.removePeer(peer.id);
 		});
 	}
 
@@ -70,6 +105,25 @@ export class PeerPool extends EventEmitter {
 	}
 
 	public removePeer(peerId: string): boolean {
+		const peer = this._peerMap.get(peerId);
+		if (peer) {
+			peer.disconnect();
+			this._unbindHandlersFromPeer(peer);
+		}
 		return this._peerMap.delete(peerId);
+	}
+
+	private _handleGetAllPeersRequest(message: ProtocolRPCRequest, respond: any) {
+		respond(null, this.getAllPeerInfos());
+	}
+
+	private _bindHandlersToPeer(peer: Peer): void {
+		peer.on(REMOTE_EVENT_RPC_REQUEST, this._handleRPC);
+		peer.on(REMOTE_EVENT_MESSAGE, this._handleMessage);
+	}
+
+	private _unbindHandlersFromPeer(peer: Peer): void {
+		peer.off(REMOTE_EVENT_RPC_REQUEST, this._handleRPC);
+		peer.off(REMOTE_EVENT_MESSAGE, this._handleMessage);
 	}
 }

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -49,8 +49,12 @@ export class PeerPool extends EventEmitter {
 		this._handlePeerRPC = (request: P2PRequest) => {
 			if (request.procedure === REMOTE_RPC_GET_ALL_PEERS_LIST) {
 				// The PeerPool has the necessary information to handle this request on its own.
+				// This request doesn't need to propagate to its parent class.
 				this._handleGetAllPeersRequest(request);
+
+				return;
 			}
+
 			// Re-emit the request to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_REQUEST_RECEIVED, request);
 		};

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -1,11 +1,14 @@
 import { expect } from 'chai';
 import { P2P } from '../../src/index';
+import { wait } from '../utils/helpers';
 
-describe.skip('Integration tests for P2P library', () => {
+const NETWORK_START_PORT = 5000;
+
+describe('Integration tests for P2P library', () => {
 	const NETWORK_PEER_COUNT = 10;
 	let p2pNodeList: ReadonlyArray<P2P> = [];
 
-	describe('Disconnected network', () => {
+	describe.skip('Disconnected network', () => {
 		beforeEach(async () => {
 			p2pNodeList = [...Array(NETWORK_PEER_COUNT).keys()].map(index => {
 				return new P2P({
@@ -13,7 +16,7 @@ describe.skip('Integration tests for P2P library', () => {
 					connectTimeout: 5000,
 					seedPeers: [],
 					wsEngine: 'ws',
-					wsPort: 5000 + index,
+					wsPort: NETWORK_START_PORT + index,
 					version: '1.0.0',
 				});
 			});
@@ -41,15 +44,23 @@ describe.skip('Integration tests for P2P library', () => {
 		});
 	});
 
-	describe.skip('Fully connected network', () => {
+	describe('Fully connected network', () => {
 		beforeEach(async () => {
 			p2pNodeList = [...Array(NETWORK_PEER_COUNT).keys()].map(index => {
+				// Each node will have the next node in the sequence as a seed peer.
+				const seedPeers = [
+					{
+						ipAddress: '127.0.0.1',
+						wsPort: NETWORK_START_PORT + ((index + 1) % NETWORK_PEER_COUNT),
+						height: 0,
+					},
+				];
 				return new P2P({
 					blacklistedPeers: [],
 					connectTimeout: 5000,
-					seedPeers: [],
+					seedPeers,
 					wsEngine: 'ws',
-					wsPort: 5000 + index,
+					wsPort: NETWORK_START_PORT + index,
 					version: '1.0.0',
 				});
 			});
@@ -60,6 +71,7 @@ describe.skip('Integration tests for P2P library', () => {
 				},
 			);
 			await Promise.all(peerStartPromises);
+			await wait(500);
 		});
 
 		afterEach(async () => {
@@ -73,6 +85,9 @@ describe.skip('Integration tests for P2P library', () => {
 		describe('Seed peer discovery', () => {
 			it('should discover seed peers', () => {
 				// TODO: Check that nodes are running and connected to seed peers using p2p.getNetworkStatus()
+				p2pNodeList.forEach(p2p => {
+					let networkStatus = p2p.getNetworkStatus();
+				});
 			});
 		});
 	});

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -70,8 +70,10 @@ describe('Integration tests for P2P library', () => {
 					return blockchainP2P.start();
 				},
 			);
+
 			await Promise.all(peerStartPromises);
 			await wait(500);
+			
 		});
 
 		afterEach(async () => {
@@ -82,11 +84,12 @@ describe('Integration tests for P2P library', () => {
 			);
 		});
 
-		describe('Seed peer discovery', () => {
+		describe('Peer discovery', () => {
 			it('should discover seed peers', () => {
 				// TODO: Check that nodes are running and connected to seed peers using p2p.getNetworkStatus()
 				p2pNodeList.forEach(p2p => {
 					let networkStatus = p2p.getNetworkStatus();
+					console.log('NETWORK STATUS:', networkStatus);
 				});
 			});
 		});

--- a/packages/lisk-p2p/test/utils/helpers.ts
+++ b/packages/lisk-p2p/test/utils/helpers.ts
@@ -1,0 +1,7 @@
+export function wait(duration: number): Promise<void> {
+	return new Promise(resolve => {
+		setTimeout(() => {
+			resolve();
+		}, duration);
+	});
+}


### PR DESCRIPTION
### What was the problem?

- There was no way for the library to externally expose inbound requests from other peers (in such a way that each request could be responded to).
- There was no mechanism for socket events to propagate to the top level P2P instance.
- There was no mechanism for handling reserved (internal) requests which could be handled internally by the P2P library.

### How did I fix it?

Implemented a request/message event bubbling mechanism. Socket requests/messages bubble up the class hierarchy `Socket -> Peer -> PeerPool -> P2P`. There exists certain request/message types which are meant to be handled internally by the P2P module. If a class within this hierarchy sees a reserved request which is relevant to it; it will respond to the request with the appropriate data and this request will not propagate to parent instances.

### How to test it?

Integration tests coming soon.

### Review checklist

* The PR resolves #896 and #981
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
