### PR TITLE
Move peer discovery and peer connection related stuff to peer pool - Closes#1019

### DIFF
--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -218,7 +218,7 @@ export class P2P extends EventEmitter {
 						version: queryObject.version,
 					};
 
-					const isNewPeer = this._peerPool.addInBoundPeer(
+					const isNewPeer = this._peerPool.addInboundPeer(
 						peerId,
 						incomingPeerInfo,
 						socket,

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -298,14 +298,7 @@ export class P2P extends EventEmitter {
 	public async start(): Promise<void> {
 		await this._startPeerServer();
 
-		const discoveredPeers = await this._runPeerDiscovery(
-			this._config.seedPeers,
-		);
-
-		// Add all the discovered peers in newPeer list
-		discoveredPeers.forEach((peerInfo: PeerInfo) => {
-			this._newPeers.add(peerInfo);
-		});
+		await this._runPeerDiscovery(this._config.seedPeers);
 
 		this._connectToPeers([...this._newPeers]);
 	}

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -228,9 +228,10 @@ export class P2P extends EventEmitter {
 					if (isNewPeer) {
 						this.emit(EVENT_NEW_INBOUND_PEER, incomingPeerInfo);
 						this.emit(EVENT_NEW_PEER, incomingPeerInfo);
-						this._newPeers.add(incomingPeerInfo);
-					} else {
-						this._newPeers.add(incomingPeerInfo);
+
+						if (!this._newPeers.has(incomingPeerInfo)) {
+							this._newPeers.add(incomingPeerInfo);
+						}
 					}
 				}
 			},

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -187,7 +187,7 @@ export class P2P extends EventEmitter {
 			'connection',
 			(socket: SCServerSocket): void => {
 				if (!socket.request.url) {
-					super.emit(EVENT_FAILED_TO_ADD_INBOUND_PEER);
+					this.emit(EVENT_FAILED_TO_ADD_INBOUND_PEER);
 					socket.disconnect(
 						INVALID_CONNECTION_URL_CODE,
 						INVALID_CONNECTION_URL_REASON,
@@ -205,7 +205,7 @@ export class P2P extends EventEmitter {
 						INVALID_CONNECTION_QUERY_CODE,
 						INVALID_CONNECTION_QUERY_REASON,
 					);
-					super.emit(EVENT_FAILED_TO_ADD_INBOUND_PEER);
+					this.emit(EVENT_FAILED_TO_ADD_INBOUND_PEER);
 				} else {
 					const wsPort: number = parseInt(queryObject.wsPort, BASE_10_RADIX);
 					const peerId = Peer.constructPeerId(socket.remoteAddress, wsPort);
@@ -226,8 +226,8 @@ export class P2P extends EventEmitter {
 					);
 
 					if (isNewPeer) {
-						super.emit(EVENT_NEW_INBOUND_PEER, incomingPeerInfo);
-						super.emit(EVENT_NEW_PEER, incomingPeerInfo);
+						this.emit(EVENT_NEW_INBOUND_PEER, incomingPeerInfo);
+						this.emit(EVENT_NEW_PEER, incomingPeerInfo);
 						this._newPeers.add(incomingPeerInfo);
 					} else {
 						this._newPeers.add(incomingPeerInfo);

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -269,16 +269,6 @@ export class P2P extends EventEmitter {
 		await this._stopHTTPServer();
 	}
 
-	private _connectToPeers(peers: ReadonlyArray<PeerInfo>): void {
-		const peersSelectedForConnection = this._peerPool.connectToPeers(peers);
-
-		// Assuming that the peers are connected
-		peersSelectedForConnection.forEach((peerInfo: PeerInfo) => {
-			this._newPeers.delete(peerInfo);
-			this._triedPeers.add(peerInfo);
-		});
-	}
-
 	private async _runPeerDiscovery(
 		peers: ReadonlyArray<PeerInfo>,
 	): Promise<ReadonlyArray<PeerInfo>> {
@@ -300,7 +290,7 @@ export class P2P extends EventEmitter {
 
 		await this._runPeerDiscovery(this._config.seedPeers);
 
-		this._connectToPeers([...this._newPeers]);
+		this._peerPool.selectPeersAndConnect([...this._newPeers]);
 	}
 
 	public async stop(): Promise<void> {

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -20,9 +20,8 @@ import { attach, SCServer, SCServerSocket } from 'socketcluster-server';
 import url from 'url';
 
 import { RequestFailError } from './errors';
-import { ConnectionState, Peer, PeerInfo } from './peer';
-import { discoverPeers } from './peer_discovery';
-import { PeerOptions, selectForConnection } from './peer_selection';
+import { Peer, PeerInfo } from './peer';
+import { PeerOptions } from './peer_selection';
 
 import {
 	INVALID_CONNECTION_QUERY_CODE,
@@ -210,28 +209,28 @@ export class P2P extends EventEmitter {
 				} else {
 					const wsPort: number = parseInt(queryObject.wsPort, BASE_10_RADIX);
 					const peerId = Peer.constructPeerId(socket.remoteAddress, wsPort);
-					const existingPeer = this._peerPool.getPeer(peerId);
-					if (existingPeer === undefined) {
-						const peer = new Peer(
-							{
-								ipAddress: socket.remoteAddress,
-								wsPort,
-								height: queryObject.height ? +queryObject.height : 0,
-								os: queryObject.os,
-								version: queryObject.version,
-							},
-							socket,
-						);
-						peer.applyNodeInfo(this._nodeInfo);
-						this._peerPool.addPeer(peer);
-						super.emit(EVENT_NEW_INBOUND_PEER, peer);
-						super.emit(EVENT_NEW_PEER, peer);
-						this._newPeers.add(peer.peerInfo);
-					} else if (
-						existingPeer.state.inbound === ConnectionState.DISCONNECTED
-					) {
-						existingPeer.inboundSocket = socket;
-						this._newPeers.add(existingPeer.peerInfo);
+
+					const incomingPeerInfo: PeerInfo = {
+						ipAddress: socket.remoteAddress,
+						wsPort,
+						height: queryObject.height ? +queryObject.height : 0,
+						os: queryObject.os,
+						version: queryObject.version,
+					};
+
+					const isNewPeer = this._peerPool.addInBoundPeer(
+						peerId,
+						incomingPeerInfo,
+						socket,
+						this._nodeInfo,
+					);
+
+					if (isNewPeer) {
+						super.emit(EVENT_NEW_INBOUND_PEER, incomingPeerInfo);
+						super.emit(EVENT_NEW_PEER, incomingPeerInfo);
+						this._newPeers.add(incomingPeerInfo);
+					} else {
+						this._newPeers.add(incomingPeerInfo);
 					}
 				}
 			},
@@ -269,35 +268,30 @@ export class P2P extends EventEmitter {
 		await this._stopHTTPServer();
 	}
 
-	private _connectToPeers(): void {
-		const availablePeers = Array.from(this._newPeers).map(
-			(peerInfo: PeerInfo) => new Peer(peerInfo),
-		);
+	private _connectToPeers(peers: ReadonlyArray<PeerInfo>): void {
+		const peersSelectedForConnection = this._peerPool.connectToPeers(peers);
 
-		const peersToConnect = selectForConnection(availablePeers);
-		peersToConnect.forEach((peer: Peer) => {
-			peer.connect();
-			this._newPeers.delete(peer.peerInfo);
-			this._triedPeers.add(peer.peerInfo);
+		// Assuming that the peers are connected
+		peersSelectedForConnection.forEach((peerInfo: PeerInfo) => {
+			this._newPeers.delete(peerInfo);
+			this._triedPeers.add(peerInfo);
 		});
 	}
 
 	private async _runPeerDiscovery(
 		peers: ReadonlyArray<PeerInfo>,
 	): Promise<ReadonlyArray<PeerInfo>> {
-		const peersObjectList = peers.map((peerInfo: PeerInfo) => {
-			const peer = new Peer(peerInfo);
-			peer.applyNodeInfo(this._nodeInfo);
-			if (!this._newPeers.has(peerInfo) && !this._triedPeers.has(peerInfo)) {
+		const discoveredPeers = await this._peerPool.runDiscovery(
+			peers,
+			this._config.blacklistedPeers,
+		);
+		discoveredPeers.forEach((peerInfo: PeerInfo) => {
+			if (!this._triedPeers.has(peerInfo) && !this._newPeers.has(peerInfo)) {
 				this._newPeers.add(peerInfo);
-				this._peerPool.addPeer(peer);
 			}
-
-			return peer;
 		});
-		const peersOfPeers = await discoverPeers(peersObjectList);
 
-		return peersOfPeers;
+		return discoveredPeers;
 	}
 
 	public async start(): Promise<void> {
@@ -312,7 +306,7 @@ export class P2P extends EventEmitter {
 			this._newPeers.add(peerInfo);
 		});
 
-		this._connectToPeers();
+		this._connectToPeers([...this._newPeers]);
 	}
 
 	public async stop(): Promise<void> {

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -114,7 +114,7 @@ export class PeerPool extends EventEmitter {
 		return disoveredPeers;
 	}
 
-	public connectToPeers(
+	public selectPeersAndConnect(
 		peers: ReadonlyArray<PeerInfo>,
 	): ReadonlyArray<PeerInfo> {
 		const availablePeers = Array.from(peers).map(

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -28,7 +28,8 @@ import {
 	EVENT_REQUEST_RECEIVED,
 	Peer,
 	PeerInfo,
-	REMOTE_RPC_GET_ALL_PEERS_LIST} from './peer';
+	REMOTE_RPC_GET_ALL_PEERS_LIST,
+} from './peer';
 import { discoverPeers } from './peer_discovery';
 import {
 	PeerOptions,
@@ -122,7 +123,6 @@ export class PeerPool extends EventEmitter {
 		const peersToConnect = selectForConnection(availablePeers);
 
 		const connectedPeerInfo = peersToConnect.map((peer: Peer) => {
-			peer.connect();
 			this.addPeer(peer);
 
 			return peer.peerInfo; // Return peerInfo to p2p to manage new/tried Peers
@@ -137,7 +137,7 @@ export class PeerPool extends EventEmitter {
 		peer.connect();
 	}
 
-	public addInBoundPeer(
+	public addInboundPeer(
 		peerId: string,
 		peerinfo: PeerInfo,
 		socket: SCServerSocket,


### PR DESCRIPTION
### Description

- Move peer selection for connection to `PeerPool`
- Move peer discovery to `PeerPool` and have an abstract function at `P2P` level to call it
- Pass `PeerInfo` to `PeerPool` instead of creating a `Peer` object for incoming connection in `P2P` and let `PeerPool` handle the connection

### Review checklist

* The PR resolves #1019 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
