### PR TITLE
Skip Fully connected network integration test and enable Disconnected network test - Closes#1031

### DIFF
--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -8,7 +8,7 @@ describe('Integration tests for P2P library', () => {
 	const NETWORK_PEER_COUNT = 10;
 	let p2pNodeList: ReadonlyArray<P2P> = [];
 
-	describe.skip('Disconnected network', () => {
+	describe('Disconnected network', () => {
 		beforeEach(async () => {
 			p2pNodeList = [...Array(NETWORK_PEER_COUNT).keys()].map(index => {
 				return new P2P({
@@ -44,7 +44,7 @@ describe('Integration tests for P2P library', () => {
 		});
 	});
 
-	describe('Fully connected network', () => {
+	describe.skip('Fully connected network', () => {
 		beforeEach(async () => {
 			p2pNodeList = [...Array(NETWORK_PEER_COUNT).keys()].map(index => {
 				// Each node will have the next node in the sequence as a seed peer.


### PR DESCRIPTION
### What was the problem?

`Fully connected network` network tests are hanging up and not finished due to missing concrete Peer objects. Also, `Disconnected network` is passing so we need to unskip it.

### How did I fix it?

Skip `Fully connected network`  and unskip `Disconnected network`

### How to test it?

`npm t`

### Review checklist

* The PR resolves #1031 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
