### PR TITLE
Fix typo in transaction pool - Closes #1034

### DIFF
--- a/packages/lisk-transaction-pool/src/transaction_pool.ts
+++ b/packages/lisk-transaction-pool/src/transaction_pool.ts
@@ -249,7 +249,7 @@ export class TransactionPool extends EventEmitter {
 		// Add transactions to the verified queue which were included in the verified removed transactions
 		this._queues.verified.enqueueMany(transactions);
 
-		this.emit(EVENT_ADDED_TRANASCTIONS, {
+		this.emit(EVENT_ADDED_TRANSACTIONS, {
 			action: ACTION_ADD_VERIFIED_REMOVED_TRANSACTIONS,
 			to: 'verified',
 			payload: transactions,
@@ -390,7 +390,7 @@ export class TransactionPool extends EventEmitter {
 
 		this._queues[queueName].enqueueOne(transaction);
 
-		this.emit(EVENT_ADDED_TRANASCTIONS, {
+		this.emit(EVENT_ADDED_TRANSACTIONS, {
 			action: ACTION_ADD_TRANSACTIONS,
 			to: queueName,
 			payload: [transaction],


### PR DESCRIPTION
### What was the problem?
AddTransactions event was spelled incorrectly.
### How did I fix it?
Fixed the spellings.
### How to test it?
Run `npm run test`
### Review checklist

* The PR resolves #1034 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
