### PR TITLE
Fix type definition in test for transaction-pool

### DIFF
--- a/packages/lisk-transaction-pool/test/integration/helpers/common.ts
+++ b/packages/lisk-transaction-pool/test/integration/helpers/common.ts
@@ -1,6 +1,6 @@
 import {
 	CheckerFunctionResponse,
-	CheckTransactionsResponse,
+	CheckTransactionsResponseWithPassAndFail,
 	Status,
 } from '../../../src/check_transactions';
 import { Transaction } from '../../../src/transaction_pool';
@@ -40,7 +40,7 @@ export const fakeCheckFunctionGenerator = (
 	return (transactions: ReadonlyArray<Transaction>) => {
 		return transactions.reduce(
 			(
-				checkedTransactions: CheckTransactionsResponse,
+				checkedTransactions: CheckTransactionsResponseWithPassAndFail,
 				transaction: Transaction,
 			) => {
 				if (!firstCharacterOfFailedTransactionsId.includes(transaction.id[0])) {
@@ -67,7 +67,7 @@ export const fakeCheckFunctionGenerator = (
 export const fakeCheckerFunctionGenerator = (
 	checkFunction: (
 		transactions: ReadonlyArray<Transaction>,
-	) => CheckTransactionsResponse,
+	) => CheckTransactionsResponseWithPassAndFail,
 ) => {
 	return (transactions: ReadonlyArray<Transaction>) => {
 		const { passedTransactions, failedTransactions } = checkFunction(


### PR DESCRIPTION
### What was the problem?
Type definition was old and it was failing in test

### How did I fix it?
Update the type definition

### How to test it?
npm t

### Review checklist

* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
