### PR TITLE
Add getAddressFromPrivateKey - Closes #952

### DIFF
--- a/packages/lisk-cryptography/src/keys.ts
+++ b/packages/lisk-cryptography/src/keys.ts
@@ -12,10 +12,10 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { bufferToHex } from './buffer';
+import { bufferToHex, hexToBuffer } from './buffer';
 import { getAddressFromPublicKey } from './convert';
 import { hash } from './hash';
-import { getKeyPair } from './nacl';
+import { getKeyPair, getPublicKey } from './nacl';
 
 export interface KeypairBytes {
 	readonly privateKeyBytes: Buffer;
@@ -69,6 +69,13 @@ export const getAddressAndPublicKeyFromPassphrase = (
 
 export const getAddressFromPassphrase = (passphrase: string): string => {
 	const { publicKey } = getKeys(passphrase);
+
+	return getAddressFromPublicKey(publicKey);
+};
+
+export const getAddressFromPrivateKey = (privateKey: string): string => {
+	const publicKeyBytes = getPublicKey(hexToBuffer(privateKey));
+	const publicKey = bufferToHex(publicKeyBytes);
 
 	return getAddressFromPublicKey(publicKey);
 };

--- a/packages/lisk-cryptography/src/nacl/fast.ts
+++ b/packages/lisk-cryptography/src/nacl/fast.ts
@@ -100,3 +100,12 @@ export const getKeyPair: NaclInterface['getKeyPair'] = hashedSeed => {
 		privateKeyBytes,
 	};
 };
+
+export const getPublicKey: NaclInterface['getPublicKey'] = privateKey => {
+	const publicKeyBytes = Buffer.alloc(sodium.crypto_sign_PUBLICKEYBYTES);
+	const privateKeyBytes = Buffer.alloc(sodium.crypto_sign_SECRETKEYBYTES);
+
+	sodium.crypto_sign_seed_keypair(publicKeyBytes, privateKeyBytes, privateKey);
+
+	return publicKeyBytes;
+};

--- a/packages/lisk-cryptography/src/nacl/index.ts
+++ b/packages/lisk-cryptography/src/nacl/index.ts
@@ -41,4 +41,5 @@ export const {
 	verifyDetached,
 	getRandomBytes,
 	getKeyPair,
+	getPublicKey,
 } = lib;

--- a/packages/lisk-cryptography/src/nacl/nacl_types.ts
+++ b/packages/lisk-cryptography/src/nacl/nacl_types.ts
@@ -8,6 +8,7 @@ export interface NaclInterface {
 		convertedPrivateKey: Buffer,
 	): Buffer;
 	getKeyPair(hashedSeed: Buffer): KeypairBytes;
+	getPublicKey(privateKey: Buffer): Buffer;
 	getRandomBytes(length: number): Buffer;
 	openBox(
 		cipherBytes: Buffer,

--- a/packages/lisk-cryptography/src/nacl/slow.ts
+++ b/packages/lisk-cryptography/src/nacl/slow.ts
@@ -69,3 +69,9 @@ export const getKeyPair: NaclInterface['getKeyPair'] = hashedSeed => {
 		publicKeyBytes: Buffer.from(publicKey),
 	};
 };
+
+export const getPublicKey: NaclInterface['getPublicKey'] = privateKey => {
+	const { publicKey } = tweetnacl.sign.keyPair.fromSeed(privateKey);
+
+	return Buffer.from(publicKey);
+};

--- a/packages/lisk-cryptography/src/nacl/slow.ts
+++ b/packages/lisk-cryptography/src/nacl/slow.ts
@@ -70,9 +70,11 @@ export const getKeyPair: NaclInterface['getKeyPair'] = hashedSeed => {
 	};
 };
 
+const PRIVATE_KEY_LENGTH = 32;
+
 export const getPublicKey: NaclInterface['getPublicKey'] = privateKey => {
 	const { publicKey } = tweetnacl.sign.keyPair.fromSeed(
-		privateKey.slice(0, tweetnacl.sign.publicKeyLength),
+		privateKey.slice(0, PRIVATE_KEY_LENGTH),
 	);
 
 	return Buffer.from(publicKey);

--- a/packages/lisk-cryptography/src/nacl/slow.ts
+++ b/packages/lisk-cryptography/src/nacl/slow.ts
@@ -71,7 +71,9 @@ export const getKeyPair: NaclInterface['getKeyPair'] = hashedSeed => {
 };
 
 export const getPublicKey: NaclInterface['getPublicKey'] = privateKey => {
-	const { publicKey } = tweetnacl.sign.keyPair.fromSeed(privateKey);
+	const { publicKey } = tweetnacl.sign.keyPair.fromSeed(
+		privateKey.slice(0, tweetnacl.sign.publicKeyLength),
+	);
 
 	return Buffer.from(publicKey);
 };

--- a/packages/lisk-cryptography/test/keys.ts
+++ b/packages/lisk-cryptography/test/keys.ts
@@ -21,6 +21,7 @@ import {
 	getKeys,
 	getAddressAndPublicKeyFromPassphrase,
 	getAddressFromPassphrase,
+	getAddressFromPrivateKey,
 } from '../src/keys';
 // Require is used for stubbing
 const buffer = require('../src/buffer');
@@ -131,6 +132,14 @@ describe('keys', () => {
 			return expect(getAddressFromPassphrase(defaultPassphrase)).to.equal(
 				defaultAddress,
 			);
+		});
+	});
+
+	describe('#getAddressFromPrivateKey', () => {
+		it('should create correct address', () => {
+			return expect(
+				getAddressFromPrivateKey(defaultPrivateKey.slice(0, 64)),
+			).to.equal(defaultAddress);
 		});
 	});
 });

--- a/packages/lisk-cryptography/test/nacl/nacl.ts
+++ b/packages/lisk-cryptography/test/nacl/nacl.ts
@@ -131,6 +131,15 @@ describe('nacl', () => {
 					);
 				});
 
+				it('should create a publicKey when private key is 32 bytes', () => {
+					publicKey = getPublicKey(
+						Buffer.from(defaultPrivateKey, 'hex').slice(0, 32),
+					);
+					return expect(Buffer.from(publicKey).toString('hex')).to.be.eql(
+						defaultPublicKey,
+					);
+				});
+
 				it('should create a publicKey of type uint8array', () => {
 					return expect(publicKey).to.be.instanceOf(Uint8Array);
 				});

--- a/packages/lisk-cryptography/test/nacl/nacl.ts
+++ b/packages/lisk-cryptography/test/nacl/nacl.ts
@@ -61,6 +61,7 @@ describe('nacl', () => {
 				box,
 				getRandomBytes,
 				getKeyPair,
+				getPublicKey,
 				openBox,
 				signDetached,
 				verifyDetached,
@@ -112,6 +113,28 @@ describe('nacl', () => {
 					return expect(signedKeys.privateKeyBytes).to.be.instanceOf(
 						Uint8Array,
 					);
+				});
+			});
+
+			describe('#getPublicKey', () => {
+				let publicKey: Buffer;
+
+				beforeEach(() => {
+					publicKey = getPublicKey(
+						Buffer.from(defaultPrivateKey.slice(0, 64), 'hex'),
+					);
+
+					return Promise.resolve();
+				});
+
+				it('should create a publicKey', () => {
+					return expect(Buffer.from(publicKey).toString('hex')).to.be.eql(
+						defaultPublicKey,
+					);
+				});
+
+				it('should create a publicKey of type uint8array', () => {
+					return expect(publicKey).to.be.instanceOf(Uint8Array);
 				});
 			});
 

--- a/packages/lisk-cryptography/test/nacl/nacl.ts
+++ b/packages/lisk-cryptography/test/nacl/nacl.ts
@@ -120,9 +120,7 @@ describe('nacl', () => {
 				let publicKey: Buffer;
 
 				beforeEach(() => {
-					publicKey = getPublicKey(
-						Buffer.from(defaultPrivateKey.slice(0, 64), 'hex'),
-					);
+					publicKey = getPublicKey(Buffer.from(defaultPrivateKey, 'hex'));
 
 					return Promise.resolve();
 				});


### PR DESCRIPTION
### What was the problem?
There was no way to generate address from private key

### How did I fix it?
Add a function to generate publicKey from private key, and then add exposed function to convert private key to address

### How to test it?
`npm t`

### Review checklist

* The PR resolves #952 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
