### PR TITLE
Add missing unit tests for custom errors in lisk-p2p - Closes#1043

### DIFF
--- a/packages/lisk-p2p/test/unit/errors.ts
+++ b/packages/lisk-p2p/test/unit/errors.ts
@@ -19,6 +19,10 @@ import {
 	PeerTransportError,
 	RPCResponseError,
 	InvalidRPCResponseError,
+	InvalidProtocolMessageError,
+	InvalidRPCRequestError,
+	RPCResponseAlreadySentError,
+	RequestFailError,
 } from '../../src';
 
 describe('errors', () => {
@@ -220,6 +224,113 @@ describe('errors', () => {
 			it('should set error message when passed an argument', () => {
 				return expect(invalidRPCResponse.message).to.eql(defaultMessage);
 			});
+		});
+	});
+
+	describe('#InvalidProtocolMessageError', () => {
+		let invalidProtocolMessageError: InvalidProtocolMessageError;
+		const defaultMessage = 'Invalid protocol message';
+
+		beforeEach(async () => {
+			invalidProtocolMessageError = new InvalidProtocolMessageError(
+				defaultMessage,
+			);
+			return Promise.resolve();
+		});
+
+		it('should create a new instance of InvalidProtocolMessageError', () => {
+			return expect(invalidProtocolMessageError)
+				.to.be.an('object')
+				.and.be.instanceof(InvalidProtocolMessageError);
+		});
+
+		it('should set error name to `InvalidProtocolMessageError`', () => {
+			return expect(invalidProtocolMessageError.name).to.eql(
+				'InvalidProtocolMessageError',
+			);
+		});
+
+		it('should set error message when passed an argument', () => {
+			return expect(invalidProtocolMessageError.message).to.eql(defaultMessage);
+		});
+	});
+
+	describe('#InvalidRPCRequestError', () => {
+		let invalidRPCRequestError: InvalidRPCRequestError;
+		const defaultMessage = 'Invalid RPC request error';
+
+		beforeEach(async () => {
+			invalidRPCRequestError = new InvalidRPCRequestError(defaultMessage);
+			return Promise.resolve();
+		});
+
+		it('should create a new instance of InvalidRPCRequestError', () => {
+			return expect(invalidRPCRequestError)
+				.to.be.an('object')
+				.and.be.instanceof(InvalidRPCRequestError);
+		});
+
+		it('should set error name to `InvalidRPCRequestError`', () => {
+			return expect(invalidRPCRequestError.name).to.eql(
+				'InvalidRPCRequestError',
+			);
+		});
+
+		it('should set error message when passed an argument', () => {
+			return expect(invalidRPCRequestError.message).to.eql(defaultMessage);
+		});
+	});
+
+	describe('#RPCResponseAlreadySentError', () => {
+		let rpcResponseAlreadySentError: RPCResponseAlreadySentError;
+		const defaultMessage = 'Response was already sent';
+
+		beforeEach(async () => {
+			rpcResponseAlreadySentError = new RPCResponseAlreadySentError(
+				defaultMessage,
+			);
+			return Promise.resolve();
+		});
+
+		it('should create a new instance of RPCResponseAlreadySentError', () => {
+			return expect(rpcResponseAlreadySentError)
+				.to.be.an('object')
+				.and.be.instanceof(RPCResponseAlreadySentError);
+		});
+
+		it('should set error name to `RPCResponseAlreadySentError`', () => {
+			return expect(rpcResponseAlreadySentError.name).to.eql(
+				'ResponseAlreadySentError',
+			);
+		});
+
+		it('should set error message when passed an argument', () => {
+			return expect(rpcResponseAlreadySentError.message).to.eql(defaultMessage);
+		});
+	});
+
+	describe('#RequestFailError', () => {
+		let requestFailError: RequestFailError;
+		const defaultMessage =
+			'Request failed due to no peers found in peer selection';
+
+		beforeEach(async () => {
+			requestFailError = new RequestFailError(defaultMessage);
+			return Promise.resolve();
+		});
+
+		it('should create a new instance of RequestFailError', () => {
+			return expect(requestFailError)
+				.to.be.an('object')
+				.and.be.instanceof(RequestFailError);
+		});
+
+		it('should set error name to `RequestFailError`', () => {
+			return expect(requestFailError.name).to.eql('RequestFailError');
+		});
+
+		it('should set error message when passed an argument', () => {
+			return expect(requestFailError.message).to.eql(defaultMessage);
 		});
 	});
 });

--- a/packages/lisk-p2p/test/unit/errors.ts
+++ b/packages/lisk-p2p/test/unit/errors.ts
@@ -27,231 +27,173 @@ import {
 
 describe('errors', () => {
 	describe('#NotEnoughPeersError', () => {
-		let notEnoughPeersError: NotEnoughPeersError;
 		const defaultMessage =
 			'Requested number of peers is greater than available good peers';
+		let notEnoughPeersError: NotEnoughPeersError;
 
-		beforeEach(() => {
+		beforeEach(async () => {
 			notEnoughPeersError = new NotEnoughPeersError(defaultMessage);
-			return Promise.resolve();
 		});
 
-		describe('should create an error object instance of NotEnoughPeersError', () => {
-			it('should create a new instance of NotEnoughPeersError', () => {
-				return expect(notEnoughPeersError)
-					.to.be.an('object')
-					.and.be.instanceof(NotEnoughPeersError);
-			});
-
-			it('should set error name to `NotEnoughPeersError`', () => {
-				return expect(notEnoughPeersError.name).to.eql('NotEnoughPeersError');
-			});
+		it('should create a new instance of NotEnoughPeersError', async () => {
+			expect(notEnoughPeersError)
+				.to.be.an('object')
+				.and.be.instanceof(NotEnoughPeersError);
 		});
 
-		describe('should set error object properties', () => {
-			beforeEach(() => {
-				notEnoughPeersError = new NotEnoughPeersError(defaultMessage);
-				return Promise.resolve();
-			});
+		it('should set error name to `NotEnoughPeersError`', async () => {
+			expect(notEnoughPeersError.name).to.eql('NotEnoughPeersError');
+		});
 
-			it('should set error message when passed an argument', () => {
-				return expect(notEnoughPeersError.message).to.eql(defaultMessage);
-			});
+		it('should set error message when passed an argument', async () => {
+			expect(notEnoughPeersError.message).to.eql(defaultMessage);
 		});
 	});
 
 	describe('#PeerTransportError', () => {
-		let peerTransportError: PeerTransportError;
-		let peerId = '0.0.0.0:80';
+		const peerId = '0.0.0.0:80';
 		const defaultMessage = `Received inbound connection from peer ${peerId} which is already in our triedPeers map.`;
+		let peerTransportError: PeerTransportError;
 
-		beforeEach(() => {
+		beforeEach(async () => {
 			peerTransportError = new PeerTransportError(defaultMessage, peerId);
-			return Promise.resolve();
 		});
 
-		describe('should create an error object', () => {
-			it('should create a new instance of PeerTransportError', () => {
-				return expect(peerTransportError)
-					.to.be.an('object')
-					.and.be.instanceof(PeerTransportError);
-			});
-
-			it('should set error name to `PeerTransportError`', () => {
-				return expect(peerTransportError.name).to.eql('PeerTransportError');
-			});
+		it('should create a new instance of PeerTransportError', async () => {
+			expect(peerTransportError)
+				.to.be.an('object')
+				.and.be.instanceof(PeerTransportError);
 		});
 
-		describe('should set error object property', () => {
-			beforeEach(() => {
-				peerTransportError = new PeerTransportError(defaultMessage, peerId);
-				return Promise.resolve();
-			});
+		it('should set error name to `PeerTransportError`', async () => {
+			expect(peerTransportError.name).to.eql('PeerTransportError');
+		});
 
-			it('should set error property peerId when passed as an argument', () => {
-				return expect(peerTransportError.peerId).to.eql(peerId);
-			});
+		it('should set error property peerId when passed as an argument', async () => {
+			expect(peerTransportError.peerId).to.eql(peerId);
 		});
 	});
 
 	describe('#RPCResponseError', () => {
-		let rpcGetPeersFailed: RPCResponseError;
 		const peerIp = '127.0.0.1:5001';
 		const peerPort = 5001;
 		const defaultMessage = `Error when fetching peerlist of peer with peer ip ${peerIp} and port ${peerPort}`;
 		const defaultError = new Error('Peer not available');
+		let rpcGetPeersFailed: RPCResponseError;
 
-		beforeEach(() => {
+		beforeEach(async () => {
 			rpcGetPeersFailed = new RPCResponseError(
 				defaultMessage,
 				defaultError,
 				peerIp,
 				peerPort,
 			);
-			return Promise.resolve();
 		});
 
-		describe('should create an error object', () => {
-			it('should create a new instance of RPCResponseError', () => {
-				return expect(rpcGetPeersFailed)
-					.to.be.an('object')
-					.and.be.instanceof(RPCResponseError);
-			});
-
-			it('should set error name to `RPCResponseError`', () => {
-				return expect(rpcGetPeersFailed.name).to.eql('RPCResponseError');
-			});
+		it('should create a new instance of RPCResponseError', async () => {
+			expect(rpcGetPeersFailed)
+				.to.be.an('object')
+				.and.be.instanceof(RPCResponseError);
 		});
 
-		describe('should set error object properties', () => {
-			beforeEach(() => {
-				rpcGetPeersFailed = new RPCResponseError(
-					defaultMessage,
-					defaultError,
-					peerIp,
-					peerPort,
-				);
-				return Promise.resolve();
-			});
+		it('should set error name to `RPCResponseError`', async () => {
+			expect(rpcGetPeersFailed.name).to.eql('RPCResponseError');
+		});
 
-			it('should set error property peer ip when passed as an argument', () => {
-				return expect(rpcGetPeersFailed)
-					.and.to.have.property('peerIp')
-					.which.is.eql(peerIp);
-			});
+		it('should set error property peer ip when passed as an argument', async () => {
+			expect(rpcGetPeersFailed)
+				.and.to.have.property('peerIp')
+				.which.is.eql(peerIp);
+		});
 
-			it('should set error property peer port when passed as an argument', () => {
-				return expect(rpcGetPeersFailed)
-					.and.to.have.property('peerPort')
-					.which.is.eql(peerPort);
-			});
+		it('should set error property peer port when passed as an argument', async () => {
+			expect(rpcGetPeersFailed)
+				.and.to.have.property('peerPort')
+				.which.is.eql(peerPort);
+		});
 
-			it('should set error property cause when passed as an argument', () => {
-				expect(rpcGetPeersFailed)
-					.and.to.have.property('cause')
-					.and.to.be.a('function');
+		it('should set error property cause when passed as an argument', async () => {
+			expect(rpcGetPeersFailed)
+				.and.to.have.property('cause')
+				.and.to.be.a('function');
 
-				return expect(rpcGetPeersFailed.cause())
-					.is.instanceOf(Error)
-					.has.property('message')
-					.and.eql('Peer not available');
-			});
+			expect(rpcGetPeersFailed.cause())
+				.is.instanceOf(Error)
+				.has.property('message')
+				.and.eql('Peer not available');
 		});
 	});
 
 	describe('#InvalidPeer', () => {
-		let invalidPeer: InvalidPeerError;
 		const defaultMessage = 'Invalid peer ip or port';
+		let invalidPeer: InvalidPeerError;
 
-		beforeEach(() => {
+		beforeEach(async () => {
 			invalidPeer = new InvalidPeerError(defaultMessage);
-			return Promise.resolve();
 		});
 
-		describe('should create an error object instance of InvalidPeer', () => {
-			it('should create a new instance of InvalidPeer', () => {
-				return expect(invalidPeer)
-					.to.be.an('object')
-					.and.be.instanceof(InvalidPeerError);
-			});
-
-			it('should set error name to `InvalidPeerError`', () => {
-				return expect(invalidPeer.name).to.eql('InvalidPeerError');
-			});
+		it('should create a new instance of InvalidPeerError', async () => {
+			expect(invalidPeer)
+				.to.be.an('object')
+				.and.be.instanceof(InvalidPeerError);
 		});
 
-		describe('should set error object properties', () => {
-			beforeEach(() => {
-				invalidPeer = new InvalidPeerError(defaultMessage);
-				return Promise.resolve();
-			});
+		it('should set error name to `InvalidPeer`', async () => {
+			expect(invalidPeer.name).to.eql('InvalidPeerError');
+		});
 
-			it('should set error message when passed an argument', () => {
-				return expect(invalidPeer.message).to.eql(defaultMessage);
-			});
+		it('should set error message when passed an argument', async () => {
+			expect(invalidPeer.message).to.eql(defaultMessage);
 		});
 	});
 
 	describe('#InvalidRPCResponse', () => {
-		let invalidRPCResponse: InvalidRPCResponseError;
 		const defaultMessage = 'Invalid response type';
+		let invalidRPCResponse: InvalidRPCResponseError;
 
-		beforeEach(() => {
+		beforeEach(async () => {
 			invalidRPCResponse = new InvalidRPCResponseError(defaultMessage);
-			return Promise.resolve();
 		});
 
-		describe('should create an error object instance of InvalidRPCResponse', () => {
-			it('should create a new instance of InvalidRPCResponse', () => {
-				return expect(invalidRPCResponse)
-					.to.be.an('object')
-					.and.be.instanceof(InvalidRPCResponseError);
-			});
-
-			it('should set error name to `InvalidRPCResponseError`', () => {
-				return expect(invalidRPCResponse.name).to.eql(
-					'InvalidRPCResponseError',
-				);
-			});
+		it('should create a new instance of InvalidRPCResponse', async () => {
+			expect(invalidRPCResponse)
+				.to.be.an('object')
+				.and.be.instanceof(InvalidRPCResponseError);
 		});
 
-		describe('should set error object properties', () => {
-			beforeEach(() => {
-				invalidRPCResponse = new InvalidRPCResponseError(defaultMessage);
-				return Promise.resolve();
-			});
+		it('should set error name to `InvalidRPCResponseError`', async () => {
+			expect(invalidRPCResponse.name).to.eql('InvalidRPCResponseError');
+		});
 
-			it('should set error message when passed an argument', () => {
-				return expect(invalidRPCResponse.message).to.eql(defaultMessage);
-			});
+		it('should set error message when passed an argument', async () => {
+			expect(invalidRPCResponse.message).to.eql(defaultMessage);
 		});
 	});
 
 	describe('#InvalidProtocolMessageError', () => {
-		let invalidProtocolMessageError: InvalidProtocolMessageError;
 		const defaultMessage = 'Invalid protocol message';
+		let invalidProtocolMessageError: InvalidProtocolMessageError;
 
 		beforeEach(async () => {
 			invalidProtocolMessageError = new InvalidProtocolMessageError(
 				defaultMessage,
 			);
-			return Promise.resolve();
 		});
 
-		it('should create a new instance of InvalidProtocolMessageError', () => {
-			return expect(invalidProtocolMessageError)
+		it('should create a new instance of InvalidProtocolMessageError', async () => {
+			expect(invalidProtocolMessageError)
 				.to.be.an('object')
 				.and.be.instanceof(InvalidProtocolMessageError);
 		});
 
-		it('should set error name to `InvalidProtocolMessageError`', () => {
-			return expect(invalidProtocolMessageError.name).to.eql(
+		it('should set error name to `InvalidProtocolMessageError`', async () => {
+			expect(invalidProtocolMessageError.name).to.eql(
 				'InvalidProtocolMessageError',
 			);
 		});
 
-		it('should set error message when passed an argument', () => {
-			return expect(invalidProtocolMessageError.message).to.eql(defaultMessage);
+		it('should set error message when passed an argument', async () => {
+			expect(invalidProtocolMessageError.message).to.eql(defaultMessage);
 		});
 	});
 
@@ -261,76 +203,73 @@ describe('errors', () => {
 
 		beforeEach(async () => {
 			invalidRPCRequestError = new InvalidRPCRequestError(defaultMessage);
-			return Promise.resolve();
 		});
 
-		it('should create a new instance of InvalidRPCRequestError', () => {
-			return expect(invalidRPCRequestError)
+		it('should create a new instance of InvalidRPCRequestError', async () => {
+			expect(invalidRPCRequestError)
 				.to.be.an('object')
 				.and.be.instanceof(InvalidRPCRequestError);
 		});
 
-		it('should set error name to `InvalidRPCRequestError`', () => {
-			return expect(invalidRPCRequestError.name).to.eql(
+		it('should set error name to `InvalidRPCRequestError`', async () => {
+			expect(invalidRPCRequestError.name).to.eql(
 				'InvalidRPCRequestError',
 			);
 		});
 
-		it('should set error message when passed an argument', () => {
-			return expect(invalidRPCRequestError.message).to.eql(defaultMessage);
+		it('should set error message when passed an argument', async () => {
+			expect(invalidRPCRequestError.message).to.eql(defaultMessage);
 		});
 	});
 
 	describe('#RPCResponseAlreadySentError', () => {
-		let rpcResponseAlreadySentError: RPCResponseAlreadySentError;
 		const defaultMessage = 'Response was already sent';
+		let rpcResponseAlreadySentError: RPCResponseAlreadySentError;
 
 		beforeEach(async () => {
 			rpcResponseAlreadySentError = new RPCResponseAlreadySentError(
 				defaultMessage,
 			);
-			return Promise.resolve();
 		});
 
-		it('should create a new instance of RPCResponseAlreadySentError', () => {
-			return expect(rpcResponseAlreadySentError)
+		it('should create a new instance of RPCResponseAlreadySentError', async () => {
+			expect(rpcResponseAlreadySentError)
 				.to.be.an('object')
 				.and.be.instanceof(RPCResponseAlreadySentError);
 		});
 
-		it('should set error name to `RPCResponseAlreadySentError`', () => {
-			return expect(rpcResponseAlreadySentError.name).to.eql(
+		it('should set error name to `RPCResponseAlreadySentError`', async () => {
+			expect(rpcResponseAlreadySentError.name).to.eql(
 				'ResponseAlreadySentError',
 			);
 		});
 
-		it('should set error message when passed an argument', () => {
-			return expect(rpcResponseAlreadySentError.message).to.eql(defaultMessage);
+		it('should set error message when passed an argument', async () => {
+			expect(rpcResponseAlreadySentError.message).to.eql(defaultMessage);
 		});
 	});
 
 	describe('#RequestFailError', () => {
-		let requestFailError: RequestFailError;
 		const defaultMessage =
 			'Request failed due to no peers found in peer selection';
+		let requestFailError: RequestFailError;
 
 		beforeEach(async () => {
 			requestFailError = new RequestFailError(defaultMessage);
-			return Promise.resolve();
 		});
 
-		it('should create a new instance of RequestFailError', () => {
-			return expect(requestFailError)
+		it('should create a new instance of RequestFailError', async () => {
+			expect(requestFailError)
 				.to.be.an('object')
 				.and.be.instanceof(RequestFailError);
 		});
 
-		it('should set error name to `RequestFailError`', () => {
-			return expect(requestFailError.name).to.eql('RequestFailError');
+		it('should set error name to `RequestFailError`', async () => {
+			expect(requestFailError.name).to.eql('RequestFailError');
 		});
 
-		it('should set error message when passed an argument', () => {
-			return expect(requestFailError.message).to.eql(defaultMessage);
+		it('should set error message when passed an argument', async () => {
+			expect(requestFailError.message).to.eql(defaultMessage);
 		});
 	});
 });


### PR DESCRIPTION
### Description

There are some missing test cases for custom error classes in lisk-p2p.
Closes a task in #970

### Review checklist

* The PR resolves #1043 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
