### PR TITLE
Need a separate peer info interface for basic and detailed peers info - Closes#1055

### DIFF
--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -30,8 +30,8 @@ import {
 } from './disconnect_status_codes';
 
 import {
-	DiscoveredPeerInfo,
 	P2PConfig,
+	P2PDiscoveredPeerInfo,
 	P2PMessagePacket,
 	P2PNetworkStatus,
 	P2PNodeInfo,
@@ -220,7 +220,7 @@ export class P2P extends EventEmitter {
 					const wsPort: number = parseInt(queryObject.wsPort, BASE_10_RADIX);
 					const peerId = Peer.constructPeerId(socket.remoteAddress, wsPort);
 
-					const incomingPeerInfo: DiscoveredPeerInfo = {
+					const incomingPeerInfo: P2PDiscoveredPeerInfo = {
 						...queryObject,
 						ipAddress: socket.remoteAddress,
 						wsPort,

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -30,6 +30,7 @@ import {
 } from './disconnect_status_codes';
 
 import {
+	DiscoveredPeerInfo,
 	P2PConfig,
 	P2PMessagePacket,
 	P2PNetworkStatus,
@@ -219,7 +220,7 @@ export class P2P extends EventEmitter {
 					const wsPort: number = parseInt(queryObject.wsPort, BASE_10_RADIX);
 					const peerId = Peer.constructPeerId(socket.remoteAddress, wsPort);
 
-					const incomingPeerInfo: P2PPeerInfo = {
+					const incomingPeerInfo: DiscoveredPeerInfo = {
 						...queryObject,
 						ipAddress: socket.remoteAddress,
 						wsPort,

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -39,7 +39,7 @@ export interface P2PPeerInfo {
 	readonly isDiscoveredPeer?: boolean;
 }
 
-export interface DiscoveredPeerInfo extends P2PPeerInfo {
+export interface P2PDiscoveredPeerInfo extends P2PPeerInfo {
 	readonly os: string;
 	readonly version: string;
 	// Add support for custom fields like broadhash or nonce.

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -34,15 +34,18 @@ export interface P2PPeerInfo {
 	readonly ipAddress: string;
 	readonly wsPort: number;
 	readonly height: number;
-	readonly os?: string;
-	readonly version?: string;
+	// This is necessary because PeerInfo for a tried peer will likely have more properties.
+	/* tslint:disable-next-line:no-mixed-interface */
+	readonly isDiscoveredPeer?: boolean;
+}
+
+export interface DiscoveredPeerInfo extends P2PPeerInfo {
+	readonly os: string;
+	readonly version: string;
 	// Add support for custom fields like broadhash or nonce.
 	// This is done to keep the P2P library general-purpose since not all P2P applications need a nonce or broadhash.
 	/* tslint:disable-next-line:no-mixed-interface */
 	readonly options?: P2PInfoOptions;
-	// This is necessary because PeerInfo for a tried peer will likely have more properties.
-	/* tslint:disable-next-line:no-mixed-interface */
-	readonly isTriedPeer?: boolean;
 }
 
 // Allows the user to provide custom fields.

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -18,7 +18,7 @@ import * as querystring from 'querystring';
 import { RPCResponseError } from './errors';
 
 import {
-	DiscoveredPeerInfo,
+	P2PDiscoveredPeerInfo,
 	P2PMessagePacket,
 	P2PNodeInfo,
 	P2PPeerInfo,
@@ -78,7 +78,7 @@ export class Peer extends EventEmitter {
 	private readonly _wsPort: number;
 	private readonly _height: number;
 	private _peerInfo: P2PPeerInfo;
-	private _peerDetailedInfo: DiscoveredPeerInfo | undefined;
+	private _peerDetailedInfo: P2PDiscoveredPeerInfo | undefined;
 	private _nodeInfo: P2PNodeInfo | undefined;
 	private _inboundSocket: SCServerSocketUpdated | undefined;
 	private _outboundSocket: SCClientSocket | undefined;
@@ -170,7 +170,7 @@ export class Peer extends EventEmitter {
 		this._outboundSocket = scClientSocket;
 	}
 
-	public updatePeerInfo(newPeerInfo: DiscoveredPeerInfo): void {
+	public updatePeerInfo(newPeerInfo: P2PDiscoveredPeerInfo): void {
 		this._peerInfo = {
 			height: newPeerInfo.height,
 			ipAddress: this._peerInfo.ipAddress,
@@ -185,7 +185,7 @@ export class Peer extends EventEmitter {
 		return this._peerInfo;
 	}
 
-	public get detailedPeerInfo(): DiscoveredPeerInfo | undefined {
+	public get detailedPeerInfo(): P2PDiscoveredPeerInfo | undefined {
 		return this._peerDetailedInfo;
 	}
 

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -18,6 +18,7 @@ import * as querystring from 'querystring';
 import { RPCResponseError } from './errors';
 
 import {
+	DiscoveredPeerInfo,
 	P2PMessagePacket,
 	P2PNodeInfo,
 	P2PPeerInfo,
@@ -77,6 +78,7 @@ export class Peer extends EventEmitter {
 	private readonly _wsPort: number;
 	private readonly _height: number;
 	private _peerInfo: P2PPeerInfo;
+	private _peerDetailedInfo: DiscoveredPeerInfo | undefined;
 	private _nodeInfo: P2PNodeInfo | undefined;
 	private _inboundSocket: SCServerSocketUpdated | undefined;
 	private _outboundSocket: SCClientSocket | undefined;
@@ -168,17 +170,23 @@ export class Peer extends EventEmitter {
 		this._outboundSocket = scClientSocket;
 	}
 
-	public updatePeerInfo(newPeerInfo: P2PPeerInfo): void {
+	public updatePeerInfo(newPeerInfo: DiscoveredPeerInfo): void {
 		this._peerInfo = {
-			...newPeerInfo,
+			height: newPeerInfo.height,
 			ipAddress: this._peerInfo.ipAddress,
 			wsPort: this._peerInfo.wsPort,
-			isTriedPeer: true,
+			isDiscoveredPeer: true,
 		};
+
+		this._peerDetailedInfo = newPeerInfo;
 	}
 
 	public get peerInfo(): P2PPeerInfo {
 		return this._peerInfo;
+	}
+
+	public get detailedPeerInfo(): DiscoveredPeerInfo | undefined {
+		return this._peerDetailedInfo;
 	}
 
 	public get state(): PeerConnectionState {

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -267,8 +267,8 @@ export class PeerPool extends EventEmitter {
 						nonce: peerDetailedInfo.options
 							? (peerDetailedInfo.options.nonce as string)
 							: '',
-						os: peerDetailedInfo.os ? peerDetailedInfo.os : '',
-						version: peerDetailedInfo.version ? peerDetailedInfo.version : '',
+						os: peerDetailedInfo.os,
+						version: peerDetailedInfo.version,
 						wsPort: String(peerDetailedInfo.wsPort),
 					};
 				},

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -256,8 +256,9 @@ export class PeerPool extends EventEmitter {
 				(peer: Peer): ProtocolPeerInfo | undefined => {
 					const peerDetailedInfo: P2PDiscoveredPeerInfo | undefined = peer.detailedPeerInfo;
 					if (!peerDetailedInfo) {
-						return;
+						return undefined;
 					}
+					
 					return {
 						broadhash: peerDetailedInfo.options
 							? (peerDetailedInfo.options.broadhash as string)

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -28,6 +28,7 @@ import {
 	P2PMessagePacket,
 	P2PNodeInfo,
 	P2PPeerInfo,
+	ProtocolPeerInfo,
 	ProtocolPeerInfoList,
 } from './p2p_types';
 import {
@@ -250,37 +251,32 @@ export class PeerPool extends EventEmitter {
 		const protocolPeerInfoList: ProtocolPeerInfoList = {
 			success: true,
 			// TODO ASAP: We need a new type to account for complete P2PPeerInfo which has all possible fields (e.g. P2PDiscoveredPeerInfo) that way we don't need to have all these checks below.
-			peers: this._pickRandomPeers(MAX_PEER_LIST_BATCH_SIZE).map(
-				(peer: Peer) => {
-					const peerDetailedInfo = peer.detailedPeerInfo;
-					const peerInfo = peer.peerInfo;
-
-					if (peerDetailedInfo) {
-						return {
-							broadhash: peerDetailedInfo.options
-								? (peerDetailedInfo.options.broadhash as string)
-								: '',
-							height: peerDetailedInfo.height,
-							ip: peerDetailedInfo.ipAddress,
-							nonce: peerDetailedInfo.options
-								? (peerDetailedInfo.options.nonce as string)
-								: '',
-							os: peerDetailedInfo.os ? peerDetailedInfo.os : '',
-							version: peerDetailedInfo.version ? peerDetailedInfo.version : '',
-							wsPort: String(peerInfo.wsPort),
-						};
+			peers: this._pickRandomPeers(MAX_PEER_LIST_BATCH_SIZE)
+			.map(
+				(peer: Peer): ProtocolPeerInfo | undefined => {
+					const peerDetailedInfo: P2PDiscoveredPeerInfo | undefined = peer.detailedPeerInfo;
+					if (!peerDetailedInfo) {
+						return;
 					}
-
 					return {
-						broadhash: '',
-						height: peerInfo.height,
-						ip: peerInfo.ipAddress,
-						nonce: '',
-						os: '',
-						version: '',
-						wsPort: String(peerInfo.wsPort),
+						broadhash: peerDetailedInfo.options
+							? (peerDetailedInfo.options.broadhash as string)
+							: '',
+						height: peerDetailedInfo.height,
+						ip: peerDetailedInfo.ipAddress,
+						nonce: peerDetailedInfo.options
+							? (peerDetailedInfo.options.nonce as string)
+							: '',
+						os: peerDetailedInfo.os ? peerDetailedInfo.os : '',
+						version: peerDetailedInfo.version ? peerDetailedInfo.version : '',
+						wsPort: String(peerDetailedInfo.wsPort),
 					};
 				},
+			)
+			.filter((peerDetailedInfo: ProtocolPeerInfo | undefined) => !!peerDetailedInfo)
+			.map(
+				(peerDetailedInfo: ProtocolPeerInfo | undefined) =>
+					peerDetailedInfo as ProtocolPeerInfo
 			),
 		};
 

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -24,7 +24,7 @@ import shuffle = require('lodash.shuffle');
 import { SCServerSocket } from 'socketcluster-server';
 import { P2PRequest } from './p2p_request';
 import {
-	DiscoveredPeerInfo,
+	P2PDiscoveredPeerInfo,
 	P2PMessagePacket,
 	P2PNodeInfo,
 	P2PPeerInfo,
@@ -158,9 +158,25 @@ export class PeerPool extends EventEmitter {
 		return peer;
 	}
 
+	public addDiscoveredPeer(
+		detailedPeerInfo: P2PDiscoveredPeerInfo,
+		inboundSocket?: SCServerSocket,
+	): Peer {
+		const peer = new Peer(detailedPeerInfo, inboundSocket);
+		this._peerMap.set(peer.id, peer);
+		this._bindHandlersToPeer(peer);
+		if (this._nodeInfo) {
+			peer.applyNodeInfo(this._nodeInfo);
+		}
+		peer.updatePeerInfo(detailedPeerInfo);
+		peer.connect();
+
+		return peer;
+	}
+
 	public addInboundPeer(
 		peerId: string,
-		peerInfo: DiscoveredPeerInfo,
+		peerInfo: P2PDiscoveredPeerInfo,
 		socket: SCServerSocket,
 	): boolean {
 		const existingPeer = this.getPeer(peerId);

--- a/packages/lisk-p2p/src/validation.ts
+++ b/packages/lisk-p2p/src/validation.ts
@@ -22,7 +22,7 @@ import {
 } from './errors';
 
 import {
-	P2PPeerInfo,
+	DiscoveredPeerInfo,
 	ProtocolMessagePacket,
 	ProtocolPeerInfo,
 	ProtocolRPCRequestPacket,
@@ -44,7 +44,7 @@ export const validatePeerAddress = (ip: string, wsPort: string): boolean => {
 	return true;
 };
 
-export const validatePeerInfo = (rawPeerInfo: unknown): P2PPeerInfo => {
+export const validatePeerInfo = (rawPeerInfo: unknown): DiscoveredPeerInfo => {
 	if (!rawPeerInfo) {
 		throw new InvalidPeerError(`Invalid peer object`);
 	}
@@ -73,7 +73,7 @@ export const validatePeerInfo = (rawPeerInfo: unknown): P2PPeerInfo => {
 			? +protocolPeer.height
 			: 0;
 
-	const peerInfo: P2PPeerInfo = {
+	const peerInfo: DiscoveredPeerInfo = {
 		ipAddress: protocolPeer.ip,
 		wsPort,
 		height,
@@ -87,14 +87,14 @@ export const validatePeerInfo = (rawPeerInfo: unknown): P2PPeerInfo => {
 
 export const validatePeerInfoList = (
 	rawPeerInfoList: unknown,
-): ReadonlyArray<P2PPeerInfo> => {
+): ReadonlyArray<DiscoveredPeerInfo> => {
 	if (!rawPeerInfoList) {
 		throw new InvalidRPCResponseError('Invalid response type');
 	}
 	const { peers } = rawPeerInfoList as RPCPeerListResponse;
 
 	if (Array.isArray(peers)) {
-		const peerList = peers.map<P2PPeerInfo>(validatePeerInfo);
+		const peerList = peers.map<DiscoveredPeerInfo>(validatePeerInfo);
 
 		return peerList;
 	} else {

--- a/packages/lisk-p2p/src/validation.ts
+++ b/packages/lisk-p2p/src/validation.ts
@@ -22,7 +22,7 @@ import {
 } from './errors';
 
 import {
-	DiscoveredPeerInfo,
+	P2PDiscoveredPeerInfo,
 	ProtocolMessagePacket,
 	ProtocolPeerInfo,
 	ProtocolRPCRequestPacket,
@@ -44,7 +44,9 @@ export const validatePeerAddress = (ip: string, wsPort: string): boolean => {
 	return true;
 };
 
-export const validatePeerInfo = (rawPeerInfo: unknown): DiscoveredPeerInfo => {
+export const validatePeerInfo = (
+	rawPeerInfo: unknown,
+): P2PDiscoveredPeerInfo => {
 	if (!rawPeerInfo) {
 		throw new InvalidPeerError(`Invalid peer object`);
 	}
@@ -73,7 +75,7 @@ export const validatePeerInfo = (rawPeerInfo: unknown): DiscoveredPeerInfo => {
 			? +protocolPeer.height
 			: 0;
 
-	const peerInfo: DiscoveredPeerInfo = {
+	const peerInfo: P2PDiscoveredPeerInfo = {
 		ipAddress: protocolPeer.ip,
 		wsPort,
 		height,
@@ -87,14 +89,14 @@ export const validatePeerInfo = (rawPeerInfo: unknown): DiscoveredPeerInfo => {
 
 export const validatePeerInfoList = (
 	rawPeerInfoList: unknown,
-): ReadonlyArray<DiscoveredPeerInfo> => {
+): ReadonlyArray<P2PDiscoveredPeerInfo> => {
 	if (!rawPeerInfoList) {
 		throw new InvalidRPCResponseError('Invalid response type');
 	}
 	const { peers } = rawPeerInfoList as RPCPeerListResponse;
 
 	if (Array.isArray(peers)) {
-		const peerList = peers.map<DiscoveredPeerInfo>(validatePeerInfo);
+		const peerList = peers.map<P2PDiscoveredPeerInfo>(validatePeerInfo);
 
 		return peerList;
 	} else {

--- a/packages/lisk-p2p/test/unit/peer.ts
+++ b/packages/lisk-p2p/test/unit/peer.ts
@@ -15,10 +15,10 @@
 import { expect } from 'chai';
 
 import { Peer } from '../../src/peer';
-import { DiscoveredPeerInfo } from '../../src/p2p_types';
+import { P2PDiscoveredPeerInfo } from '../../src/p2p_types';
 
 describe('peer', () => {
-	const defaultPeerInfo: DiscoveredPeerInfo = {
+	const defaultPeerInfo: P2PDiscoveredPeerInfo = {
 		ipAddress: '12.12.12.12',
 		wsPort: 5001,
 		height: 545776,

--- a/packages/lisk-p2p/test/unit/peer.ts
+++ b/packages/lisk-p2p/test/unit/peer.ts
@@ -15,10 +15,10 @@
 import { expect } from 'chai';
 
 import { Peer } from '../../src/peer';
-import { P2PPeerInfo } from '../../src/p2p_types';
+import { DiscoveredPeerInfo } from '../../src/p2p_types';
 
 describe('peer', () => {
-	const defaultPeerInfo: P2PPeerInfo = {
+	const defaultPeerInfo: DiscoveredPeerInfo = {
 		ipAddress: '12.12.12.12',
 		wsPort: 5001,
 		height: 545776,

--- a/packages/lisk-p2p/test/unit/peer_discovery.ts
+++ b/packages/lisk-p2p/test/unit/peer_discovery.ts
@@ -26,25 +26,19 @@ describe('peer discovery', () => {
 	const validatedPeer1: P2PPeerInfo = {
 		ipAddress: '196.34.89.90',
 		wsPort: 5393,
-		os: 'darwin',
 		height: 23232,
-		version: '1.1.2',
 	};
 
 	const validatedPeer2: P2PPeerInfo = {
 		ipAddress: '128.38.75.9',
 		wsPort: 5393,
-		os: 'darwin',
 		height: 23232,
-		version: '1.1.2',
 	};
 
 	const validatedPeer3: P2PPeerInfo = {
 		ipAddress: '12.23.11.31',
 		wsPort: 5393,
-		os: 'darwin',
 		height: 23232,
-		version: '1.1.2',
 	};
 
 	describe('#discoverPeer', () => {

--- a/packages/lisk-p2p/test/utils/peers.ts
+++ b/packages/lisk-p2p/test/utils/peers.ts
@@ -20,40 +20,30 @@ export const initializePeerInfoList = (): ReadonlyArray<P2PPeerInfo> => {
 		ipAddress: '12.12.12.12',
 		wsPort: 5001,
 		height: 545776,
-		version: '1.0.1',
-		os: 'darwin',
 	};
 
 	const peerOption2: P2PPeerInfo = {
 		ipAddress: '127.0.0.1',
 		wsPort: 5002,
 		height: 545981,
-		version: '1.0.1',
-		os: 'darwin',
 	};
 
 	const peerOption3: P2PPeerInfo = {
 		ipAddress: '18.28.48.1',
 		wsPort: 5008,
 		height: 645980,
-		version: '1.4.1',
-		os: 'darwin',
 	};
 
 	const peerOption4: P2PPeerInfo = {
 		ipAddress: '192.28.138.1',
 		wsPort: 5006,
 		height: 645982,
-		version: '1.0.1',
-		os: 'darwin',
 	};
 
 	const peerOption5: P2PPeerInfo = {
 		ipAddress: '178.21.90.199',
 		wsPort: 5001,
 		height: 645980,
-		version: '1.0.1',
-		os: 'darwin',
 	};
 
 	return [peerOption1, peerOption2, peerOption3, peerOption4, peerOption5];


### PR DESCRIPTION
### Description

We need separate Peer info for basic peer information that we don't have much information yet and a detailed PeerInfo for discovered peers for which we have more information.

### Review checklist

* The PR resolves #1055 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
