### PR TITLE
Change selectPeers function to only handle detailed PeerInfo objects; not live Peer objects Closes#1059

### DIFF
--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -170,13 +170,13 @@ export class P2P extends EventEmitter {
 
 	// TODO ASAP: Change selectPeers to return PeerInfo list and then make request on peerPool itself; pass peerInfo as argument.
 	public async request(packet: P2PRequestPacket): Promise<P2PResponsePacket> {
-		const response = await this._peerPool.requestPeer(packet, this._nodeInfo);
+		const response = await this._peerPool.requestPeer(packet);
 
 		return response;
 	}
 
 	public send(message: P2PMessagePacket): void {
-		this._peerPool.sendToPeers(message, this._nodeInfo);
+		this._peerPool.sendToPeers(message);
 	}
 
 	private async _startPeerServer(): Promise<void> {

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -22,9 +22,7 @@ interface SCServerUpdated extends SCServer {
 	readonly isReady: boolean;
 }
 
-import { RequestFailError } from './errors';
-import { constructPeerId, constructPeerIdFromPeerInfo, Peer } from './peer';
-import { PeerOptions } from './peer_selection';
+import { constructPeerId, constructPeerIdFromPeerInfo } from './peer';
 
 import {
 	INVALID_CONNECTION_QUERY_CODE,

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -170,30 +170,13 @@ export class P2P extends EventEmitter {
 
 	// TODO ASAP: Change selectPeers to return PeerInfo list and then make request on peerPool itself; pass peerInfo as argument.
 	public async request(packet: P2PRequestPacket): Promise<P2PResponsePacket> {
-		const peerSelectionParams: PeerOptions = {
-			lastBlockHeight: this._nodeInfo.height,
-		};
-		const selectedPeer = this._peerPool.selectPeers(peerSelectionParams, 1);
-
-		if (selectedPeer.length <= 0) {
-			throw new RequestFailError(
-				'Request failed due to no peers found in peer selection',
-			);
-		}
-		const response: P2PResponsePacket = await selectedPeer[0].request(packet);
+		const response = await this._peerPool.requestPeer(packet, this._nodeInfo);
 
 		return response;
 	}
 
 	public send(message: P2PMessagePacket): void {
-		const peerSelectionParams: PeerOptions = {
-			lastBlockHeight: this._nodeInfo.height,
-		};
-		const selectedPeers = this._peerPool.selectPeers(peerSelectionParams);
-
-		selectedPeers.forEach((peer: Peer) => {
-			peer.send(message);
-		});
+		this._peerPool.sendToPeers(message, this._nodeInfo);
 	}
 
 	private async _startPeerServer(): Promise<void> {

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -370,6 +370,10 @@ export class Peer extends EventEmitter {
 		inboundSocket.off(REMOTE_EVENT_MESSAGE, this._handleRawMessage);
 	}
 
+	public static constructPeerIdFromPeerInfo(peerInfo: P2PPeerInfo): string {
+		return `${peerInfo.ipAddress}:${peerInfo.wsPort}`;
+	}
+
 	private _handlePeerInfo(request: P2PRequest): void {
 		// Update peerInfo with the latest values from the remote peer.
 		try {

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -22,11 +22,14 @@ import { EventEmitter } from 'events';
 // tslint:disable-next-line no-require-imports
 import shuffle = require('lodash.shuffle');
 import { SCServerSocket } from 'socketcluster-server';
+import { RequestFailError } from './errors';
 import { P2PRequest } from './p2p_request';
 import {
 	P2PMessagePacket,
 	P2PNodeInfo,
 	P2PPeerInfo,
+	P2PRequestPacket,
+	P2PResponsePacket,
 	ProtocolPeerInfoList,
 } from './p2p_types';
 import {
@@ -108,14 +111,62 @@ export class PeerPool extends EventEmitter {
 	public selectPeers(
 		selectionParams: PeerOptions,
 		numOfPeers?: number,
-	): ReadonlyArray<Peer> {
+	): ReadonlyArray<P2PPeerInfo> {
+		const listOfPeerInfo = [...this._peerMap.values()].map(
+			(peer: Peer) => peer.peerInfo,
+		);
 		const selectedPeers = selectPeers(
-			[...this._peerMap.values()],
+			listOfPeerInfo,
 			selectionParams,
 			numOfPeers,
 		);
 
 		return selectedPeers;
+	}
+
+	public async requestPeer(
+		packet: P2PRequestPacket,
+		nodeInfo: P2PNodeInfo,
+	): Promise<P2PResponsePacket> {
+		const peerSelectionParams: PeerOptions = {
+			lastBlockHeight: nodeInfo.height,
+		};
+		const selectedPeer = this.selectPeers(peerSelectionParams, 1);
+
+		if (selectedPeer.length <= 0) {
+			throw new RequestFailError(
+				'Request failed due to no peers found in peer selection',
+			);
+		}
+
+		const selectedPeerId = Peer.constructPeerIdFromPeerInfo(selectedPeer[0]);
+		const peer = this._peerMap.get(selectedPeerId);
+
+		if (!peer) {
+			throw new RequestFailError(
+				`No such Peer exist in PeerPool with the selected peer with Id: ${selectedPeerId}`,
+			);
+		}
+
+		const response: P2PResponsePacket = await peer.request(packet);
+
+		return response;
+	}
+
+	public sendToPeers(message: P2PMessagePacket, nodeInfo: P2PNodeInfo): void {
+		const peerSelectionParams: PeerOptions = {
+			lastBlockHeight: nodeInfo.height,
+		};
+		const selectedPeers = this.selectPeers(peerSelectionParams);
+
+		selectedPeers.forEach((peerInfo: P2PPeerInfo) => {
+			const selectedPeerId = Peer.constructPeerIdFromPeerInfo(peerInfo);
+			const peer = this._peerMap.get(selectedPeerId);
+
+			if (peer) {
+				peer.send(message);
+			}
+		});
 	}
 
 	public async runDiscovery(

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -126,10 +126,9 @@ export class PeerPool extends EventEmitter {
 
 	public async requestPeer(
 		packet: P2PRequestPacket,
-		nodeInfo: P2PNodeInfo,
 	): Promise<P2PResponsePacket> {
 		const peerSelectionParams: PeerOptions = {
-			lastBlockHeight: nodeInfo.height,
+			lastBlockHeight: this._nodeInfo ? this._nodeInfo.height : 0,
 		};
 		const selectedPeer = this.selectPeers(peerSelectionParams, 1);
 
@@ -153,9 +152,9 @@ export class PeerPool extends EventEmitter {
 		return response;
 	}
 
-	public sendToPeers(message: P2PMessagePacket, nodeInfo: P2PNodeInfo): void {
+	public sendToPeers(message: P2PMessagePacket): void {
 		const peerSelectionParams: PeerOptions = {
-			lastBlockHeight: nodeInfo.height,
+			lastBlockHeight: this._nodeInfo ? this._nodeInfo.height : 0,
 		};
 		const selectedPeers = this.selectPeers(peerSelectionParams);
 

--- a/packages/lisk-p2p/src/peer_selection.ts
+++ b/packages/lisk-p2p/src/peer_selection.ts
@@ -14,7 +14,6 @@
  */
 import { NotEnoughPeersError } from './errors';
 import { P2PPeerInfo } from './p2p_types';
-import { Peer } from './peer';
 
 export interface PeerOptions {
 	readonly [key: string]: string | number;
@@ -32,13 +31,13 @@ interface HistogramValues {
 // TODO ASAP: Consider changing selectPeers function to handle P2PDiscoveredPeerInfo instead of Peer objects.
 /* tslint:enable: readonly-keyword */
 export const selectPeers = (
-	peers: ReadonlyArray<Peer>,
+	peers: ReadonlyArray<P2PPeerInfo>,
 	selectionParams: PeerOptions = { lastBlockHeight: 0 },
 	numOfPeers: number = 0,
-): ReadonlyArray<Peer> => {
+): ReadonlyArray<P2PPeerInfo> => {
 	const filteredPeers = peers.filter(
 		// Remove unreachable peers or heights below last block height
-		(peer: Peer) => peer.height >= selectionParams.lastBlockHeight,
+		(peer: P2PPeerInfo) => peer.height >= selectionParams.lastBlockHeight,
 	);
 
 	if (filteredPeers.length === 0) {
@@ -51,7 +50,7 @@ export const selectPeers = (
 	const aggregation = 2;
 
 	const calculatedHistogramValues = sortedPeers.reduce(
-		(histogramValues: HistogramValues, peer: Peer) => {
+		(histogramValues: HistogramValues, peer: P2PPeerInfo) => {
 			const val = Math.floor(peer.height / aggregation) * aggregation;
 			histogramValues.histogram[val] =
 				(histogramValues.histogram[val] ? histogramValues.histogram[val] : 0) +
@@ -67,10 +66,11 @@ export const selectPeers = (
 	);
 
 	// Perform histogram cut of peers too far from histogram maximum
-	const processedPeers = sortedPeers.filter(peer => peer &&
-		Math.abs(
-			calculatedHistogramValues.height - peer.height
-		) < aggregation + 1
+	const processedPeers = sortedPeers.filter(
+		peer =>
+			peer &&
+			Math.abs(calculatedHistogramValues.height - peer.height) <
+				aggregation + 1,
 	);
 
 	if (numOfPeers <= 0) {
@@ -91,7 +91,7 @@ export const selectPeers = (
 	}
 
 	if (numOfPeers === 1) {
-		const goodPeer: ReadonlyArray<Peer> = [
+		const goodPeer: ReadonlyArray<P2PPeerInfo> = [
 			processedPeers[Math.floor(Math.random() * processedPeers.length)],
 		];
 
@@ -106,7 +106,7 @@ export const selectPeers = (
 			const peer = peerListObject.processedPeersArray[index];
 			// This will ensure that the selected peer is not choosen again by the random function above
 			const tempProcessedPeers = peerListObject.processedPeersArray.filter(
-				(findPeer: Peer) => findPeer !== peer,
+				(findPeer: P2PPeerInfo) => findPeer !== peer,
 			);
 
 			return {


### PR DESCRIPTION
### Description

Currently, the `selectPeers` function accepts and returns a list of `Peer` objects (`ReadonlyArray<Peer>`). We should make the `selectPeers` function in `peer_selection.ts` work with detailed peer info objects instead of live Peer objects.

### Review checklist

* The PR resolves #1059
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
