### PR TITLE
Update P2P header should include options - Closes #1071

### DIFF
--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -215,12 +215,14 @@ export class P2P extends EventEmitter {
 					const peerId = constructPeerId(socket.remoteAddress, wsPort);
 
 					const incomingPeerInfo: P2PDiscoveredPeerInfo = {
-						...queryObject,
 						ipAddress: socket.remoteAddress,
 						wsPort,
 						height: queryObject.height ? +queryObject.height : 0,
+						isDiscoveredPeer: true,
 						os: queryObject.os,
 						version: queryObject.version,
+						options: typeof queryObject.options === 'string' ?
+							JSON.parse(queryObject.options) : undefined,
 					};
 
 					const isNewPeer = this._peerPool.addInboundPeer(

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -345,7 +345,11 @@ export class Peer extends EventEmitter {
 		const outboundSocket = socketClusterClient.create({
 			hostname: this._ipAddress,
 			port: this._wsPort,
-			query: querystring.stringify(legacyNodeInfo),
+			query: querystring.stringify({
+				...legacyNodeInfo,
+				options: legacyNodeInfo && legacyNodeInfo.options ?
+					JSON.stringify(legacyNodeInfo.options) : undefined,
+			}),
 			autoConnect: false,
 		});
 

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -103,7 +103,7 @@ export class PeerPool extends EventEmitter {
 	public applyNodeInfo(nodeInfo: P2PNodeInfo): void {
 		this._nodeInfo = nodeInfo;
 		const peerList = this.getAllPeers();
-		peerList.forEach(async peer => {
+		peerList.forEach(peer => {
 			this._applyNodeInfoOnPeer(peer, nodeInfo);
 		});
 	}


### PR DESCRIPTION
### What was the problem?

The `querystring.stringify()` function which was used to stringify `P2PNodeInfo` objects could not handle the nested `options` object so it was removing it.

### How did I fix it?

Used `JSON.stringify` to stringify the nested `options` object; that way it can be passed as a query parameter.

### How to test it?

`npm run test:integration`

Note that this affects the protocol.

### Review checklist

* The PR resolves #1071
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
