### PR TITLE
Receiving blocks, transactions and signatures from v1 lisk core - Closes #1081

### DIFF
--- a/packages/lisk-p2p/src/errors.ts
+++ b/packages/lisk-p2p/src/errors.ts
@@ -15,13 +15,17 @@
 /* tslint:disable: max-classes-per-file */
 import * as VError from 'verror';
 
-export class PeerTransportError extends VError {
-	public peerId: string;
+export class PeerInboundHandshakeError extends VError {
+	public statusCode: number;
+	public remoteAddress: string;
+	public handshakeURL?: string;
 
-	public constructor(message: string, peerId: string) {
+	public constructor(message: string, statusCode: number, remoteAddress: string, handshakeURL?: string) {
 		super(message);
-		this.name = 'PeerTransportError';
-		this.peerId = peerId;
+		this.name = 'PeerInboundHandshakeError';
+		this.statusCode = statusCode;
+		this.remoteAddress = remoteAddress;
+		this.handshakeURL = handshakeURL;
 	}
 }
 

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -33,6 +33,8 @@ import {
 	INVALID_CONNECTION_URL_REASON,
 } from './disconnect_status_codes';
 
+import { PeerInboundHandshakeError } from './errors'
+
 import {
 	P2PConfig,
 	P2PDiscoveredPeerInfo,
@@ -212,9 +214,15 @@ export class P2P extends EventEmitter {
 			'connection',
 			(socket: SCServerSocket): void => {
 				if (!socket.request.url) {
-					this.emit(EVENT_FAILED_TO_ADD_INBOUND_PEER, {
-						remoteAddress: socket.remoteAddress
-					});
+					this.emit(
+						EVENT_FAILED_TO_ADD_INBOUND_PEER,
+						new PeerInboundHandshakeError(
+							INVALID_CONNECTION_URL_REASON,
+							INVALID_CONNECTION_URL_CODE,
+							socket.remoteAddress,
+							socket.request.url,
+						),
+					);
 					socket.disconnect(
 						INVALID_CONNECTION_URL_CODE,
 						INVALID_CONNECTION_URL_REASON,
@@ -226,7 +234,6 @@ export class P2P extends EventEmitter {
 
 				if (
 					typeof queryObject.wsPort !== 'string' ||
-					typeof queryObject.os !== 'string' ||
 					typeof queryObject.version !== 'string' ||
 					typeof queryObject.nethash !== 'string'
 				) {
@@ -234,9 +241,14 @@ export class P2P extends EventEmitter {
 						INVALID_CONNECTION_QUERY_CODE,
 						INVALID_CONNECTION_QUERY_REASON,
 					);
-					this.emit(EVENT_FAILED_TO_ADD_INBOUND_PEER, {
-						remoteAddress: socket.remoteAddress
-					});
+					this.emit(EVENT_FAILED_TO_ADD_INBOUND_PEER,
+						new PeerInboundHandshakeError(
+							INVALID_CONNECTION_QUERY_REASON,
+							INVALID_CONNECTION_QUERY_CODE,
+							socket.remoteAddress,
+							socket.request.url,
+						),	
+					);
 
 					return;
 				}
@@ -246,9 +258,14 @@ export class P2P extends EventEmitter {
 						INCOMPATIBLE_NETWORK_CODE,
 						INCOMPATIBLE_NETWORK_REASON,
 					);
-					this.emit(EVENT_FAILED_TO_ADD_INBOUND_PEER, {
-						remoteAddress: socket.remoteAddress
-					});
+					this.emit(EVENT_FAILED_TO_ADD_INBOUND_PEER,
+						new PeerInboundHandshakeError(
+							INCOMPATIBLE_NETWORK_REASON,
+							INCOMPATIBLE_NETWORK_CODE,
+							socket.remoteAddress,
+							socket.request.url,
+						),	
+					);
 
 					return;
 				}
@@ -261,7 +278,6 @@ export class P2P extends EventEmitter {
 					wsPort,
 					height: queryObject.height ? +queryObject.height : 0,
 					isDiscoveredPeer: true,
-					os: queryObject.os,
 					version: queryObject.version,
 					options: typeof queryObject.options === 'string' ?
 						JSON.parse(queryObject.options) : undefined,

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -47,7 +47,7 @@ export interface P2PPeerInfo {
 }
 
 export interface P2PDiscoveredPeerInfo extends P2PPeerInfo {
-	readonly os: string;
+	readonly os?: string;
 	readonly version: string;
 	// Add support for custom fields like broadhash or nonce.
 	// This is done to keep the P2P library general-purpose since not all P2P applications need a nonce or broadhash.

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -239,10 +239,10 @@ export class Peer extends EventEmitter {
 		};
 
 		this._peerDetailedInfo = {
+			...this._peerInfo,
 			os: newPeerInfo.os,
 			version: newPeerInfo.version,
 			options: newPeerInfo.options,
-			...this._peerInfo,
 		};
 	}
 

--- a/packages/lisk-p2p/test/unit/errors.ts
+++ b/packages/lisk-p2p/test/unit/errors.ts
@@ -16,7 +16,7 @@ import { expect } from 'chai';
 import {
 	InvalidPeerError,
 	NotEnoughPeersError,
-	PeerTransportError,
+	PeerInboundHandshakeError,
 	RPCResponseError,
 	InvalidRPCResponseError,
 	InvalidProtocolMessageError,
@@ -50,27 +50,27 @@ describe('errors', () => {
 		});
 	});
 
-	describe('#PeerTransportError', () => {
-		const peerId = '0.0.0.0:80';
-		const defaultMessage = `Received inbound connection from peer ${peerId} which is already in our triedPeers map.`;
-		let peerTransportError: PeerTransportError;
+	describe('#PeerInboundHandshakeError', () => {
+		const remoteAddress = '127.0.0.1';
+		const defaultMessage = `Received inbound connection from peer ${remoteAddress} which is already in our triedPeers map.`;
+		let peerTransportError: PeerInboundHandshakeError;
 
 		beforeEach(async () => {
-			peerTransportError = new PeerTransportError(defaultMessage, peerId);
+			peerTransportError = new PeerInboundHandshakeError(defaultMessage, remoteAddress);
 		});
 
-		it('should create a new instance of PeerTransportError', async () => {
+		it('should create a new instance of PeerInboundHandshakeError', async () => {
 			expect(peerTransportError)
 				.to.be.an('object')
-				.and.be.instanceof(PeerTransportError);
+				.and.be.instanceof(PeerInboundHandshakeError);
 		});
 
-		it('should set error name to `PeerTransportError`', async () => {
-			expect(peerTransportError.name).to.eql('PeerTransportError');
+		it('should set error name to `PeerInboundHandshakeError`', async () => {
+			expect(peerTransportError.name).to.eql('PeerInboundHandshakeError');
 		});
 
-		it('should set error property peerId when passed as an argument', async () => {
-			expect(peerTransportError.peerId).to.eql(peerId);
+		it('should set error property remoteAddress when passed as an argument', async () => {
+			expect(peerTransportError.remoteAddress).to.eql(remoteAddress);
 		});
 	});
 

--- a/packages/lisk-p2p/test/unit/errors.ts
+++ b/packages/lisk-p2p/test/unit/errors.ts
@@ -52,11 +52,12 @@ describe('errors', () => {
 
 	describe('#PeerInboundHandshakeError', () => {
 		const remoteAddress = '127.0.0.1';
+		const statusCode = 4501;
 		const defaultMessage = `Received inbound connection from peer ${remoteAddress} which is already in our triedPeers map.`;
 		let peerTransportError: PeerInboundHandshakeError;
 
 		beforeEach(async () => {
-			peerTransportError = new PeerInboundHandshakeError(defaultMessage, remoteAddress);
+			peerTransportError = new PeerInboundHandshakeError(defaultMessage, statusCode, remoteAddress);
 		});
 
 		it('should create a new instance of PeerInboundHandshakeError', async () => {


### PR DESCRIPTION
### What was the problem?

Inbound messages such as blocks, transactions and signatures were not received.

### How did I fix it?

Added legacy event handlers to handle the three legacy cases.

### How to test it?

Run node on remote testnet.

### Review checklist

* The PR resolves #1081
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
