### PR TITLE
Need to handle inbound status RPC request - Closes #1082

### DIFF
--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -36,6 +36,7 @@ import {
 } from './p2p_types';
 import {
 	ConnectionState,
+	constructPeerIdFromPeerInfo,
 	EVENT_CONNECT_ABORT_OUTBOUND,
 	EVENT_CONNECT_OUTBOUND,
 	EVENT_INBOUND_SOCKET_ERROR,
@@ -156,7 +157,7 @@ export class PeerPool extends EventEmitter {
 			);
 		}
 
-		const selectedPeerId = Peer.constructPeerIdFromPeerInfo(selectedPeer[0]);
+		const selectedPeerId = constructPeerIdFromPeerInfo(selectedPeer[0]);
 		const peer = this._peerMap.get(selectedPeerId);
 
 		if (!peer) {
@@ -177,7 +178,7 @@ export class PeerPool extends EventEmitter {
 		const selectedPeers = this.selectPeers(peerSelectionParams);
 
 		selectedPeers.forEach((peerInfo: P2PPeerInfo) => {
-			const selectedPeerId = Peer.constructPeerIdFromPeerInfo(peerInfo);
+			const selectedPeerId = constructPeerIdFromPeerInfo(peerInfo);
 			const peer = this._peerMap.get(selectedPeerId);
 
 			if (peer) {


### PR DESCRIPTION
### What was the problem?

Peers where making `status` RPC requests against the P2P node but the P2P library was not handling them.

### How did I fix it?

Added handlers to respond to `status` requests using our P2PNodeInfo (after converting it into the current v1 protocol format).

### How to test it?

Run a P2P sample app on testnet.

### Review checklist

* The PR resolves #1082 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
