### PR TITLE
Add get or default to explicitly get the default account

### DIFF
--- a/packages/lisk-transactions/src/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/0_transfer_transaction.ts
@@ -22,7 +22,12 @@ import {
 import { MAX_TRANSACTION_AMOUNT, TRANSFER_FEE } from './constants';
 import { TransactionError, TransactionMultiError } from './errors';
 import { TransactionJSON } from './transaction_types';
-import { validateAddress, validateTransferAmount, validator, verifyBalance } from './utils';
+import {
+	validateAddress,
+	validateTransferAmount,
+	validator,
+	verifyBalance,
+} from './utils';
 
 const TRANSACTION_TRANSFER_TYPE = 0;
 
@@ -186,7 +191,7 @@ export class TransferTransaction extends BaseTransaction {
 			balance: updatedSenderBalance.toString(),
 		};
 		store.account.set(updatedSender.address, updatedSender);
-		const recipient = store.account.get(this.recipientId);
+		const recipient = store.account.getOrDefault(this.recipientId);
 
 		const updatedRecipientBalance = new BigNum(recipient.balance).add(
 			this.amount,
@@ -219,7 +224,7 @@ export class TransferTransaction extends BaseTransaction {
 			balance: updatedSenderBalance.toString(),
 		};
 		store.account.set(updatedSender.address, updatedSender);
-		const recipient = store.account.get(this.recipientId);
+		const recipient = store.account.getOrDefault(this.recipientId);
 
 		const balanceError = verifyBalance(this.id, recipient, this.amount);
 

--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -68,12 +68,18 @@ export interface StateStoreGetter<T> {
 	find(func: (item: T) => boolean): T | undefined;
 }
 
+export interface StateStoreDefaultGetter<T> {
+	getOrDefault(key: string): T;
+}
+
 export interface StateStoreSetter<T> {
 	set(key: string, value: T): void;
 }
 
 export interface StateStore {
-	readonly account: StateStoreGetter<Account> & StateStoreSetter<Account>;
+	readonly account: StateStoreGetter<Account> &
+		StateStoreDefaultGetter<Account> &
+		StateStoreSetter<Account>;
 	readonly transaction: StateStoreGetter<TransactionJSON>;
 }
 
@@ -275,7 +281,7 @@ export abstract class BaseTransaction {
 		if (
 			this._multisignatureStatus === MultisignatureStatus.PENDING &&
 			errors.length === 1 &&
-			errors[0] instanceof TransactionPendingError 
+			errors[0] instanceof TransactionPendingError
 		) {
 			return {
 				id: this.id,

--- a/packages/lisk-transactions/src/transaction_types.ts
+++ b/packages/lisk-transactions/src/transaction_types.ts
@@ -18,7 +18,7 @@ export interface Account {
 	readonly address: string;
 	readonly balance: string;
 	readonly delegate?: Delegate;
-	readonly publicKey: string;
+	readonly publicKey?: string;
 	readonly secondPublicKey?: string;
 	readonly multisignatures?: ReadonlyArray<string>;
 	readonly multimin?: number;

--- a/packages/lisk-transactions/src/utils/verify.ts
+++ b/packages/lisk-transactions/src/utils/verify.ts
@@ -27,8 +27,14 @@ export const verifySenderPublicKey = (
 	sender: Account,
 	publicKey: string,
 ): TransactionError | undefined =>
-	sender.publicKey !== publicKey
-		? new TransactionError('Invalid sender publicKey', id, '.senderPublicKey')
+	sender.publicKey && sender.publicKey !== publicKey
+		? new TransactionError(
+				'Invalid sender publicKey',
+				id,
+				'.senderPublicKey',
+				sender.publicKey,
+				publicKey,
+		  )
 		: undefined;
 
 export const verifySenderId = (
@@ -37,7 +43,13 @@ export const verifySenderId = (
 	address: string,
 ): TransactionError | undefined =>
 	sender.address.toUpperCase() !== address.toUpperCase()
-		? new TransactionError('Invalid sender address', id, '.senderId')
+		? new TransactionError(
+				'Invalid sender address',
+				id,
+				'.senderId',
+				sender.address.toUpperCase(),
+				address.toUpperCase(),
+		  )
 		: undefined;
 
 export const verifyBalance = (

--- a/packages/lisk-transactions/test/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/test/0_transfer_transaction.ts
@@ -170,6 +170,11 @@ describe('Transfer transaction class', () => {
 			store.account.get = () => {
 				return {
 					...sender,
+				};
+			};
+			store.account.getOrDefault = () => {
+				return {
+					...recipient,
 					balance: new BigNum(MAX_TRANSACTION_AMOUNT),
 				};
 			};
@@ -180,7 +185,7 @@ describe('Transfer transaction class', () => {
 
 	describe('#undoAsset', () => {
 		it('should return error when recipient balance is insufficient', async () => {
-			store.account.get = () => {
+			store.account.getOrDefault = () => {
 				return {
 					...recipient,
 					balance: new BigNum('0'),

--- a/packages/lisk-transactions/test/helpers/state_store.ts
+++ b/packages/lisk-transactions/test/helpers/state_store.ts
@@ -25,6 +25,9 @@ const setter = {
 	get: () => {
 		return { ...validAccount };
 	},
+	getOrDefault: () => {
+		return { ...validAccount };
+	},
 	set: () => {
 		return;
 	},


### PR DESCRIPTION
### What was the problem?
It was ambiguous when account get initialized by default value.

### How did I fix it?
Add getOrDefault function from store

### How to test it?
`npm t`

### Review checklist

* The PR resolves #1091 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
