### PR TITLE
Change to allow number for fee and amount in constructor

### DIFF
--- a/packages/lisk-cryptography/types/browserify-bignum/index.d.ts
+++ b/packages/lisk-cryptography/types/browserify-bignum/index.d.ts
@@ -21,7 +21,7 @@ declare module 'browserify-bignum' {
 		static prime(bits: number, safe?: boolean): BigNum;
 
 		/** Create a new BigNum from n. */
-		constructor(n: number | BigNum);
+		constructor(n: number | string | BigNum);
 
 		/** Create a new BigNum from n and a base. */
 		constructor(n: string, base?: number);

--- a/packages/lisk-transactions/src/transaction_types.ts
+++ b/packages/lisk-transactions/src/transaction_types.ts
@@ -33,9 +33,9 @@ export interface Delegate {
 }
 
 export interface TransactionJSON {
-	readonly amount: string;
+	readonly amount: string | number;
 	readonly asset: object;
-	readonly fee: string;
+	readonly fee: string | number;
 	readonly id?: string;
 	readonly recipientId: string;
 	readonly recipientPublicKey?: string;

--- a/packages/lisk-transactions/src/utils/validation/schema.ts
+++ b/packages/lisk-transactions/src/utils/validation/schema.ts
@@ -30,10 +30,10 @@ export const transaction = {
 			type: 'string',
 		},
 		amount: {
-			type: 'string',
+			type: ['string', 'integer'],
 		},
 		fee: {
-			type: 'string',
+			type: ['string', 'integer'],
 		},
 		type: {
 			type: 'integer',

--- a/packages/lisk-transactions/types/browserify-bignum/index.d.ts
+++ b/packages/lisk-transactions/types/browserify-bignum/index.d.ts
@@ -21,7 +21,7 @@ declare module 'browserify-bignum' {
 		static prime(bits: number, safe?: boolean): BigNum;
 
 		/** Create a new BigNum from n. */
-		constructor(n: number | BigNum);
+		constructor(n: number | string | BigNum);
 
 		/** Create a new BigNum from n and a base. */
 		constructor(n: string, base?: number);


### PR DESCRIPTION
### What was the problem?
In current protocol, for amount and fee should be allowed to be passed in constructor.

### How did I fix it?
Update TransactionJSON to be string | number and updated BigNum definition

### How to test it?
Pass in amount or fee as number in constructor and observe it doesn't throw error

### Review checklist

* The PR resolves #1096 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
