### PR TITLE
Revert getOrDefault for state store

### DIFF
--- a/packages/lisk-transactions/src/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/0_transfer_transaction.ts
@@ -191,7 +191,7 @@ export class TransferTransaction extends BaseTransaction {
 			balance: updatedSenderBalance.toString(),
 		};
 		store.account.set(updatedSender.address, updatedSender);
-		const recipient = store.account.getOrDefault(this.recipientId);
+		const recipient = store.account.get(this.recipientId);
 
 		const updatedRecipientBalance = new BigNum(recipient.balance).add(
 			this.amount,
@@ -224,7 +224,7 @@ export class TransferTransaction extends BaseTransaction {
 			balance: updatedSenderBalance.toString(),
 		};
 		store.account.set(updatedSender.address, updatedSender);
-		const recipient = store.account.getOrDefault(this.recipientId);
+		const recipient = store.account.get(this.recipientId);
 
 		const balanceError = verifyBalance(this.id, recipient, this.amount);
 

--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -68,18 +68,12 @@ export interface StateStoreGetter<T> {
 	find(func: (item: T) => boolean): T | undefined;
 }
 
-export interface StateStoreDefaultGetter<T> {
-	getOrDefault(key: string): T;
-}
-
 export interface StateStoreSetter<T> {
 	set(key: string, value: T): void;
 }
 
 export interface StateStore {
-	readonly account: StateStoreGetter<Account> &
-		StateStoreDefaultGetter<Account> &
-		StateStoreSetter<Account>;
+	readonly account: StateStoreGetter<Account> & StateStoreSetter<Account>;
 	readonly transaction: StateStoreGetter<TransactionJSON>;
 }
 

--- a/packages/lisk-transactions/test/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/test/0_transfer_transaction.ts
@@ -170,11 +170,6 @@ describe('Transfer transaction class', () => {
 			store.account.get = () => {
 				return {
 					...sender,
-				};
-			};
-			store.account.getOrDefault = () => {
-				return {
-					...recipient,
 					balance: new BigNum(MAX_TRANSACTION_AMOUNT),
 				};
 			};
@@ -185,7 +180,7 @@ describe('Transfer transaction class', () => {
 
 	describe('#undoAsset', () => {
 		it('should return error when recipient balance is insufficient', async () => {
-			store.account.getOrDefault = () => {
+			store.account.get = () => {
 				return {
 					...recipient,
 					balance: new BigNum('0'),

--- a/packages/lisk-transactions/test/helpers/state_store.ts
+++ b/packages/lisk-transactions/test/helpers/state_store.ts
@@ -25,9 +25,6 @@ const setter = {
 	get: () => {
 		return { ...validAccount };
 	},
-	getOrDefault: () => {
-		return { ...validAccount };
-	},
 	set: () => {
 		return;
 	},


### PR DESCRIPTION
### What was the problem?
Revert the #1093 because following current protocol, there was no case to use `getOrDefault` where it always should be fall back to getting default for account

### Review checklist

* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
