### PR TITLE
Disconnect old peers, cleanup node and improve timeouts - Closes #1086

### DIFF
--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -389,7 +389,8 @@ export class P2P extends EventEmitter {
 			this._config.blacklistedPeers,
 		);
 
-		// Make sure that we do not try to connect to peers if the P2P node is no longer active.
+		// Stop discovery if node is no longer active. That way we don't try to connect to peers.
+		// We need to check again because of the previous asynchronous await statement.
 		if (!this._isActive) {
 			
 			return;

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -92,7 +92,7 @@ export class P2P extends EventEmitter {
 	private readonly _httpServer: http.Server;
 	private _isActive: boolean;
 	private readonly _newPeers: Map<string, P2PPeerInfo>;
-	private readonly _triedPeers: Map<string, P2PPeerInfo>;
+	private readonly _triedPeers: Map<string, P2PDiscoveredPeerInfo>;
 	private readonly _discoveryInterval: number;
 	private _discoveryIntervalId: NodeJS.Timer | undefined;
 
@@ -115,8 +115,8 @@ export class P2P extends EventEmitter {
 		super();
 		this._config = config;
 		this._isActive = false;
-		this._newPeers = new Map<string, P2PPeerInfo>();
-		this._triedPeers = new Map<string, P2PDiscoveredPeerInfo>();
+		this._newPeers = new Map();
+		this._triedPeers = new Map();
 
 		this._httpServer = http.createServer();
 		this._scServer = attach(this._httpServer) as SCServerUpdated;
@@ -376,7 +376,7 @@ export class P2P extends EventEmitter {
 	}
 
 	private async _discoverPeers(knownPeers: ReadonlyArray<P2PPeerInfo> = []): Promise<void> {
-		const allKnownPeers = [...this._triedPeers.values()].concat(knownPeers);
+		const allKnownPeers: ReadonlyArray<P2PPeerInfo> = knownPeers.concat([...this._triedPeers.values()]);
 		
 		// Make sure that we do not try to connect to peers if the P2P node is no longer active.
 		if (!this._isActive) {

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -55,6 +55,7 @@ import {
 	EVENT_CLOSE_OUTBOUND,
 	EVENT_CONNECT_ABORT_OUTBOUND,
 	EVENT_CONNECT_OUTBOUND,
+	EVENT_DISCOVERED_PEER,
 	EVENT_FAILED_TO_FETCH_PEER_INFO,
 	EVENT_FAILED_TO_PUSH_NODE_INFO,
 	EVENT_INBOUND_SOCKET_ERROR,
@@ -62,7 +63,6 @@ import {
 	EVENT_OUTBOUND_SOCKET_ERROR,
 	EVENT_REQUEST_RECEIVED,
 	PeerPool,
-	EVENT_DISCOVERED_PEER,
 } from './peer_pool';
 
 export {
@@ -437,7 +437,7 @@ export class P2P extends EventEmitter {
 		}
 		this._stopDiscovery();
 		this._peerPool.removeAllPeers();
-		this._stopPeerServer();
+		await this._stopPeerServer();
 	}
 
 	private _bindHandlersToPeerPool(peerPool: PeerPool): void {

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -74,7 +74,8 @@ export interface P2PClosePacket {
 
 export interface P2PConfig {
 	readonly blacklistedPeers: ReadonlyArray<P2PPeerInfo>;
-	readonly connectTimeout: number;
+	readonly connectTimeout?: number;
+	readonly ackTimeout?: number;
 	readonly hostAddress?: string;
 	readonly seedPeers: ReadonlyArray<P2PPeerInfo>;
 	readonly nodeInfo: P2PNodeInfo;

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -66,6 +66,12 @@ export interface P2PNodeInfo {
 	readonly options?: P2PInfoOptions;
 }
 
+export interface P2PClosePacket {
+	readonly peerInfo: P2PPeerInfo,
+	readonly code: number,
+	readonly reason?: string,
+}
+
 export interface P2PConfig {
 	readonly blacklistedPeers: ReadonlyArray<P2PPeerInfo>;
 	readonly connectTimeout: number;

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -53,6 +53,7 @@ export interface P2PDiscoveredPeerInfo extends P2PPeerInfo {
 	// This is done to keep the P2P library general-purpose since not all P2P applications need a nonce or broadhash.
 	/* tslint:disable-next-line:no-mixed-interface */
 	readonly options?: P2PInfoOptions;
+	readonly isDiscoveredPeer: boolean;
 }
 
 // P2PPeerInfo and P2PNodeInfo are related.

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -500,11 +500,11 @@ export class Peer extends EventEmitter {
 		});
 
 		outboundSocket.on('connect', () => {
-			this.emit(EVENT_CONNECT_OUTBOUND, this);
+			this.emit(EVENT_CONNECT_OUTBOUND, this._peerInfo);
 		});
 
 		outboundSocket.on('connectAbort', () => {
-			this.emit(EVENT_CONNECT_ABORT_OUTBOUND, this);
+			this.emit(EVENT_CONNECT_ABORT_OUTBOUND, this._peerInfo);
 		});
 
 		outboundSocket.on('close', (code, reason) => {

--- a/packages/lisk-p2p/src/peer_discovery.ts
+++ b/packages/lisk-p2p/src/peer_discovery.ts
@@ -12,7 +12,7 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { P2PPeerInfo } from './p2p_types';
+import { P2PDiscoveredPeerInfo } from './p2p_types';
 import { constructPeerIdFromPeerInfo, Peer } from './peer';
 // For Lips, this will be used for fixed and white lists
 export interface FilterPeerOptions {
@@ -22,9 +22,9 @@ export interface FilterPeerOptions {
 export const discoverPeers = async (
 	knownPeers: ReadonlyArray<Peer>,
 	filterPeerOptions: FilterPeerOptions = { blacklist: [] },
-): Promise<ReadonlyArray<P2PPeerInfo>> => {
+): Promise<ReadonlyArray<P2PDiscoveredPeerInfo>> => {
 	const peersOfPeer: ReadonlyArray<
-		ReadonlyArray<P2PPeerInfo>
+		ReadonlyArray<P2PDiscoveredPeerInfo>
 	> = await Promise.all(
 		knownPeers.map(
 			async peer => {
@@ -38,7 +38,7 @@ export const discoverPeers = async (
 	);
 
 	const peersOfPeerFlat = peersOfPeer.reduce(
-		(flattenedPeersList: ReadonlyArray<P2PPeerInfo>, peersList) =>
+		(flattenedPeersList: ReadonlyArray<P2PDiscoveredPeerInfo>, peersList) =>
 			Array.isArray(peersList)
 				? [...flattenedPeersList, ...peersList]
 				: flattenedPeersList,
@@ -47,7 +47,7 @@ export const discoverPeers = async (
 
 	// Remove duplicates
 	const discoveredPeers = peersOfPeerFlat.reduce(
-		(uniquePeersArray: ReadonlyArray<P2PPeerInfo>, peer: P2PPeerInfo) => {
+		(uniquePeersArray: ReadonlyArray<P2PDiscoveredPeerInfo>, peer: P2PDiscoveredPeerInfo) => {
 			const found = uniquePeersArray.find(
 				findPeer => constructPeerIdFromPeerInfo(findPeer) === constructPeerIdFromPeerInfo(peer),
 			);
@@ -62,7 +62,7 @@ export const discoverPeers = async (
 	}
 	// Remove blacklist ids
 	const discoveredPeersFiltered = discoveredPeers.filter(
-		(peer: P2PPeerInfo) =>
+		(peer: P2PDiscoveredPeerInfo) =>
 			!filterPeerOptions.blacklist.includes(peer.ipAddress),
 	);
 

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -235,8 +235,10 @@ export class PeerPool extends EventEmitter {
 				if (peerInfo.isDiscoveredPeer) {
 					existingPeer.updatePeerInfo(peerInfo as P2PDiscoveredPeerInfo);
 				}
+				
 				return existingPeer;
 			}
+
 			return this.addPeer(peerInfo);
 		});
 

--- a/packages/lisk-p2p/src/validation.ts
+++ b/packages/lisk-p2p/src/validation.ts
@@ -47,6 +47,27 @@ export const validatePeerAddress = (ip: string, wsPort: number): boolean => {
 	return true;
 };
 
+export const validateStatusProtocolPeerInfo = (
+	rawPeerInfo: unknown,
+): ProtocolPeerInfo => {
+	if (!rawPeerInfo) {
+		throw new InvalidPeerError(`Invalid peer object`);
+	}
+
+	const protocolPeer = rawPeerInfo as ProtocolPeerInfo;
+	if (
+		!protocolPeer.wsPort
+	) {
+		throw new InvalidPeerError(`Invalid peer ip or port`);
+	}
+
+	if (!protocolPeer.version || !isValidVersion(protocolPeer.version)) {
+		throw new InvalidPeerError(`Invalid peer version`);
+	}
+
+	return protocolPeer;
+};
+
 export const validatePeerInfo = (
 	rawPeerInfo: unknown,
 ): P2PDiscoveredPeerInfo => {
@@ -82,6 +103,7 @@ export const validatePeerInfo = (
 		os,
 		version,
 		options: protocolPeer,
+		isDiscoveredPeer: true,
 	};
 
 	return peerInfo;

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -137,7 +137,7 @@ describe('Integration tests for P2P library', () => {
 	});
 
 	describe('Partially connected network which becomes fully connected: All nodes launch at the same time. The seedPeers list of each node contains the next node in the sequence. Discovery interval runs multiple times.', () => {
-		const DISCOVERY_INTERVAL = 300;
+		const DISCOVERY_INTERVAL = 200;
 		
 		beforeEach(async () => {
 			p2pNodeList = [...Array(NETWORK_PEER_COUNT).keys()].map(index => {
@@ -155,8 +155,8 @@ describe('Integration tests for P2P library', () => {
 					seedPeers,
 					wsEngine: 'ws',
 					// A short connectTimeout and ackTimeout will make the node to give up on discovery quicker for our test.
-					connectTimeout: 200,
-					ackTimeout: 200,
+					connectTimeout: 100,
+					ackTimeout: 100,
 					// Set a different discoveryInterval for each node; that way they don't keep trying to discover each other at the same time.
 					discoveryInterval: DISCOVERY_INTERVAL + index * 11,
 					nodeInfo: {

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -45,8 +45,10 @@ describe('Integration tests for P2P library', () => {
 
 		afterEach(async () => {
 			await Promise.all(
-				p2pNodeList.map(p2p => {
-					return p2p.stop();
+				p2pNodeList.map(async p2p => {
+					try {
+						await p2p.stop();
+					} catch (error) {} // Ignore error. This can happen if a test case intentionally stops a node.
 				}),
 			);
 		});
@@ -100,8 +102,10 @@ describe('Integration tests for P2P library', () => {
 
 		afterEach(async () => {
 			await Promise.all(
-				p2pNodeList.map(p2p => {
-					return p2p.stop();
+				p2pNodeList.map(async p2p => {
+					try {
+						await p2p.stop();
+					} catch (error) {} // Ignore error. This can happen if a test case intentionally stops a node.
 				}),
 			);
 		});
@@ -133,7 +137,7 @@ describe('Integration tests for P2P library', () => {
 	});
 
 	describe('Partially connected network which becomes fully connected: All nodes launch at the same time. The seedPeers list of each node contains the next node in the sequence. Discovery interval runs multiple times.', () => {
-		const DISCOVERY_INTERVAL = 100;
+		const DISCOVERY_INTERVAL = 300;
 		
 		beforeEach(async () => {
 			p2pNodeList = [...Array(NETWORK_PEER_COUNT).keys()].map(index => {
@@ -148,9 +152,11 @@ describe('Integration tests for P2P library', () => {
 
 				return new P2P({
 					blacklistedPeers: [],
-					connectTimeout: 5000,
 					seedPeers,
 					wsEngine: 'ws',
+					// A short connectTimeout and ackTimeout will make the node to give up on discovery quicker for our test.
+					connectTimeout: 200,
+					ackTimeout: 200,
 					// Set a different discoveryInterval for each node; that way they don't keep trying to discover each other at the same time.
 					discoveryInterval: DISCOVERY_INTERVAL + index * 11,
 					nodeInfo: {
@@ -178,8 +184,10 @@ describe('Integration tests for P2P library', () => {
 
 		afterEach(async () => {
 			await Promise.all(
-				p2pNodeList.map(p2p => {
-					return p2p.stop();
+				p2pNodeList.map(async p2p => {
+					try {
+						await p2p.stop();
+					} catch (error) {} // Ignore error. This can happen if a test case intentionally stops a node.
 				}),
 			);
 		});
@@ -251,9 +259,10 @@ describe('Integration tests for P2P library', () => {
 				p2pNodeList.map(async p2p => {
 					try {
 						await p2p.stop();
-					} catch (error) {} // Ignore. This can happen if a test case intentionally stops a node.
+					} catch (error) {} // Ignore error. This can happen if a test case intentionally stops a node.
 				}),
 			);
+			await wait(100);
 		});
 
 		describe('Peer discovery', () => {
@@ -313,7 +322,7 @@ describe('Integration tests for P2P library', () => {
 		});
 
 		describe('Cleanup unresponsive peers', () => {
-			it('should remove peers which we cannot connect to', async () => {
+			it('should remove peers which cannot be reached', async () => {
 				const initialNetworkStatus = p2pNodeList[2].getNetworkStatus();
 				const initialPeerPorts = initialNetworkStatus.connectedPeers
 					.map(peerInfo => peerInfo.wsPort)
@@ -322,7 +331,7 @@ describe('Integration tests for P2P library', () => {
 				expect(initialPeerPorts).to.be.eql(ALL_NODE_PORTS);
 
 				await p2pNodeList[0].stop();
-				await wait(500);
+				await wait(100);
 
 				const networkStatusAfterPeerCrash = p2pNodeList[2].getNetworkStatus();
 

--- a/packages/lisk-p2p/test/unit/peer.ts
+++ b/packages/lisk-p2p/test/unit/peer.ts
@@ -24,6 +24,7 @@ describe('peer', () => {
 		height: 545776,
 		os: 'darwin',
 		version: '1.1.0',
+		isDiscoveredPeer: true
 	};
 
 	const defaultPeer = new Peer(defaultPeerInfo);

--- a/packages/lisk-p2p/test/unit/peer_discovery.ts
+++ b/packages/lisk-p2p/test/unit/peer_discovery.ts
@@ -13,7 +13,7 @@
  *
  */
 import { expect } from 'chai';
-import { P2PPeerInfo } from '../../src/p2p_types';
+import { P2PPeerInfo, P2PDiscoveredPeerInfo } from '../../src/p2p_types';
 import { initializePeerList } from '../utils/peers';
 import * as discoverPeersModule from '../../src/peer_discovery';
 
@@ -23,22 +23,31 @@ describe('peer discovery', () => {
 	const seedPeer2 = samplePeers[1];
 	const seedList = [seedPeer1, seedPeer2];
 
-	const validatedPeer1: P2PPeerInfo = {
+	const validatedPeer1: P2PDiscoveredPeerInfo = {
 		ipAddress: '196.34.89.90',
 		wsPort: 5393,
 		height: 23232,
+		os: 'linux',
+		version: '1.0.0',
+		isDiscoveredPeer: true,
 	};
 
-	const validatedPeer2: P2PPeerInfo = {
+	const validatedPeer2: P2PDiscoveredPeerInfo = {
 		ipAddress: '128.38.75.9',
 		wsPort: 5393,
 		height: 23232,
+		os: 'linux',
+		version: '1.0.0',
+		isDiscoveredPeer: true,
 	};
 
-	const validatedPeer3: P2PPeerInfo = {
+	const validatedPeer3: P2PDiscoveredPeerInfo = {
 		ipAddress: '12.23.11.31',
 		wsPort: 5393,
 		height: 23232,
+		os: 'linux',
+		version: '1.0.0',
+		isDiscoveredPeer: true,
 	};
 
 	describe('#discoverPeer', () => {

--- a/packages/lisk-p2p/test/unit/validation.ts
+++ b/packages/lisk-p2p/test/unit/validation.ts
@@ -230,6 +230,7 @@ describe('response handlers', () => {
 				peer['ipAddress'] = peer.ip;
 				peer.wsPort = +peer.wsPort;
 				peer.height = +peer.height;
+				peer.isDiscoveredPeer = true;
 				peer.options = peer;
 				delete peer.ip;
 


### PR DESCRIPTION
### What was the problem?

- There was no mechanism to fully disconnect from peers which could not be reached.
- There was an issue in the integration tests which meant that P2P node would not aways stop correctly.
- There was no mechanism for configuring timeout values on the P2P node.

### How did I fix it?

- If a peer cannot be reached from our outbound connection, we remove them from our PeerPool. It's possible that the node may try again at a later time when the next round of discovery will run; this is configurable by the user.
- Fixed a bug related to a missing option passed to the client socket which means that sockets were being reused and event handlers were accumulating on them.
- Added an new `ackTimeout` to allow the user to specify an upper bound on how long it should take to perform requests (including discovery).
- Cleanup issue related to the P2P stop() method not resolving in some scenarios.
- Added an integration test case to verify that stopping one of the P2P nodes in the network causes other peers to remove that node from their PeerPool.

**EDIT** (after PR feedback)
- The `isDiscoveredPeer` property is now compulsory on the `P2PDiscoveredPeerInfo` interface because we need to always differentiate between these two objects internally.
- The P2P node now makes a `peer.fetchStatus()` 'status' call after connecting on the outbound connection; we need to make this call in order to get the full `P2PDiscoveredPeerInfo` from the outbound connection.
- Changed `_triedPeers` to be of type `Map<string, P2PDiscoveredPeerInfo>` (only the full discovered peers info is allowed); we should not have undiscovered peers in there as it will cause issues in other parts of the logic.
- `_triedPeers` is now populated using a new event on the `PeerPool` called `EVENT_DISCOVERED_PEER`; this event carries the full `P2PDiscoveredPeerInfo`
- Improved the solution for the P2P stop() method not resolving.

### How to test it?

`npm run test:integration`

### Review checklist

* The PR resolves #1086 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
