### PR TITLE
Remove duplicate balance error - Closes #1105

### DIFF
--- a/packages/lisk-transactions/fixtures/valid_transfer_transactions.json
+++ b/packages/lisk-transactions/fixtures/valid_transfer_transactions.json
@@ -7,7 +7,7 @@
 		"senderId": "1977368676922172803L",
 		"recipientId": "7675634738153324567L",
 		"recipientPublicKey": "",
-		"amount": "1",
+		"amount": "10000001",
 		"fee": "10000000",
 		"signature": "bc42403a1a29bcd786839c13d8f84e39d30ff486e032b755bcd1cf9a74c9ef1817ab94f5eccbc61959daf2b2f23721edc1848ee707f9d74dbf2f6f38fe1ada0a",
 		"signatures": [],

--- a/packages/lisk-transactions/src/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/0_transfer_transaction.ts
@@ -179,9 +179,9 @@ export class TransferTransaction extends BaseTransaction {
 	protected applyAsset(store: StateStore): ReadonlyArray<TransactionError> {
 		const errors: TransactionError[] = [];
 		const sender = store.account.get(this.senderId);
-
 		const balanceError = verifyBalance(this.id, sender, this.amount);
-		if (balanceError) {
+		// Only return error if account has enough funds for fee to avoid duplicate errors
+		if (balanceError && new BigNum(sender.balance).gte(0)) {
 			errors.push(balanceError);
 		}
 		const updatedSenderBalance = new BigNum(sender.balance).sub(this.amount);

--- a/packages/lisk-transactions/src/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/0_transfer_transaction.ts
@@ -26,6 +26,7 @@ import {
 	validateAddress,
 	validateTransferAmount,
 	validator,
+	verifyAmountBalance,
 	verifyBalance,
 } from './utils';
 
@@ -179,11 +180,12 @@ export class TransferTransaction extends BaseTransaction {
 	protected applyAsset(store: StateStore): ReadonlyArray<TransactionError> {
 		const errors: TransactionError[] = [];
 		const sender = store.account.get(this.senderId);
-		const balanceError = verifyBalance(this.id, sender, this.amount);
-		// Only return error if account has enough funds for fee to avoid duplicate errors
-		if (balanceError && new BigNum(sender.balance).gte(0)) {
+		
+		const balanceError = verifyAmountBalance(this.id, sender, this.amount, this.fee);
+		if(balanceError) {
 			errors.push(balanceError);
 		}
+		
 		const updatedSenderBalance = new BigNum(sender.balance).sub(this.amount);
 
 		const updatedSender = {

--- a/packages/lisk-transactions/src/6_in_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/6_in_transfer_transaction.ts
@@ -206,7 +206,8 @@ export class InTransferTransaction extends BaseTransaction {
 		const sender = store.account.get(this.senderId);
 
 		const updatedBalance = new BigNum(sender.balance).sub(this.amount);
-		if (updatedBalance.lt(0)) {
+		// Only return error if account has enough funds for fee to avoid duplicate errors
+		if (new BigNum(sender.balance).gte(0) && updatedBalance.lt(0)) {
 			errors.push(
 				new TransactionError(
 					`Account does not have enough LSK: ${

--- a/packages/lisk-transactions/src/7_out_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/7_out_transfer_transaction.ts
@@ -21,7 +21,7 @@ import {
 import { MAX_TRANSACTION_AMOUNT, OUT_TRANSFER_FEE } from './constants';
 import { TransactionError, TransactionMultiError } from './errors';
 import { TransactionJSON } from './transaction_types';
-import { convertBeddowsToLSK } from './utils';
+import { verifyAmountBalance } from './utils';
 import { validator } from './utils/validation';
 
 const TRANSACTION_OUTTRANSFER_TYPE = 7;
@@ -245,18 +245,13 @@ export class OutTransferTransaction extends BaseTransaction {
 		}
 
 		const sender = store.account.get(this.senderId);
-		const updatedBalance = new BigNum(sender.balance).sub(this.amount);
-		// Only return error if account has enough funds for fee to avoid duplicate errors
-		if (new BigNum(sender.balance).gte(0) && updatedBalance.lt(0)) {
-			errors.push(
-				new TransactionError(
-					`Account does not have enough LSK: ${
-						sender.address
-					}, balance: ${convertBeddowsToLSK(sender.balance)}.`,
-					this.id,
-				),
-			);
+
+		const balanceError = verifyAmountBalance(this.id, sender, this.amount, this.fee);
+		if(balanceError) {
+			errors.push(balanceError);
 		}
+		
+		const updatedBalance = new BigNum(sender.balance).sub(this.amount);
 
 		const updatedSender = { ...sender, balance: updatedBalance.toString() };
 		store.account.set(updatedSender.address, updatedSender);

--- a/packages/lisk-transactions/src/7_out_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/7_out_transfer_transaction.ts
@@ -246,8 +246,8 @@ export class OutTransferTransaction extends BaseTransaction {
 
 		const sender = store.account.get(this.senderId);
 		const updatedBalance = new BigNum(sender.balance).sub(this.amount);
-
-		if (updatedBalance.lt(0)) {
+		// Only return error if account has enough funds for fee to avoid duplicate errors
+		if (new BigNum(sender.balance).gte(0) && updatedBalance.lt(0)) {
 			errors.push(
 				new TransactionError(
 					`Account does not have enough LSK: ${

--- a/packages/lisk-transactions/src/utils/verify.ts
+++ b/packages/lisk-transactions/src/utils/verify.ts
@@ -67,6 +67,26 @@ export const verifyBalance = (
 		  )
 		: undefined;
 
+export const verifyAmountBalance = (
+	id: string,
+	account: Account,
+	amount: BigNum,
+	fee: BigNum,
+): TransactionError | undefined => {
+	const balance = new BigNum(account.balance);
+	if (balance.gte(0) && balance.lt(new BigNum(amount))) {
+		return new TransactionError(
+			`Account does not have enough LSK: ${
+				account.address
+			}, balance: ${convertBeddowsToLSK(balance.plus(fee).toString())}`,
+			id,
+			'.balance',
+		);
+	}
+
+	return undefined;
+};
+
 export const verifySecondSignature = (
 	id: string,
 	sender: Account,

--- a/packages/lisk-transactions/test/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/test/0_transfer_transaction.ts
@@ -204,7 +204,7 @@ describe('Transfer transaction class', () => {
 			const errors = (validTransferTestTransaction as any).applyAsset(store);
 			expect(errors).to.have.length(1);
 			expect(errors[0].message).to.equal(
-				`Account does not have enough LSK: ${sender.address}, balance: 0.1`,
+				`Account does not have enough LSK: ${sender.address}, balance: 0.2`,
 			);
 		});
 

--- a/packages/lisk-transactions/test/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/test/0_transfer_transaction.ts
@@ -199,11 +199,12 @@ describe('Transfer transaction class', () => {
 		it('should return error when sender balance is insufficient', async () => {
 			storeAccountGetStub.returns({
 				...sender,
-				balance: new BigNum('0'),
+				balance: new BigNum(10000000),
 			});
 			const errors = (validTransferTestTransaction as any).applyAsset(store);
+			expect(errors).to.have.length(1);
 			expect(errors[0].message).to.equal(
-				`Account does not have enough LSK: ${sender.address}, balance: 0`,
+				`Account does not have enough LSK: ${sender.address}, balance: 0.1`,
 			);
 		});
 

--- a/packages/lisk-transactions/test/7_out_transfer_transaction.ts
+++ b/packages/lisk-transactions/test/7_out_transfer_transaction.ts
@@ -305,7 +305,7 @@ describe('outTransfer transaction class', () => {
 			expect(errors[0].message).to.equal(
 				`Account does not have enough LSK: ${
 					defaultValidSender.address
-				}, balance: 0.`,
+				}, balance: 0.1`,
 			);
 		});
 	});


### PR DESCRIPTION
### What was the problem?

`verifyBalance` called in Base (for fee check) and in Transfer (and other `amount` transactions) causing duplicate insufficient balance errors.

### How did I fix it?

In Transfer, InTransfer, and OutTransfer: added extra check to make sure balance had at least enough funds for the fee, before returning balance error for `amount` to avoid duplicate errors. 

### How to test it?

npm test

### Review checklist

* The PR resolves #1105 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
