### PR TITLE
Validate null character - Closes #1108

### DIFF
--- a/packages/lisk-transactions/src/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/0_transfer_transaction.ts
@@ -49,6 +49,7 @@ export const transferAssetFormatSchema = {
 	properties: {
 		data: {
 			type: 'string',
+			format: 'noNullByte',
 			maxLength: 64,
 		},
 	},

--- a/packages/lisk-transactions/src/5_dapp_transaction.ts
+++ b/packages/lisk-transactions/src/5_dapp_transaction.ts
@@ -102,14 +102,17 @@ export const dappAssetFormatSchema = {
 				},
 				tags: {
 					type: 'string',
+					format: 'noNullByte',
 					maxLength: 160,
 				},
 				description: {
 					type: 'string',
+					format: 'noNullByte',
 					maxLength: 160,
 				},
 				name: {
 					type: 'string',
+					format: 'noNullByte',
 					minLength: 1,
 					maxLength: 32,
 				},

--- a/packages/lisk-transactions/src/utils/validation/validation.ts
+++ b/packages/lisk-transactions/src/utils/validation/validation.ts
@@ -168,3 +168,6 @@ export const isUnique = (values: ReadonlyArray<string>): boolean => {
 
 	return unique.length === values.length;
 };
+
+export const isNullByteIncluded = (input: string) =>
+	new RegExp('\\0|\\U00000000').test(input);

--- a/packages/lisk-transactions/src/utils/validation/validation.ts
+++ b/packages/lisk-transactions/src/utils/validation/validation.ts
@@ -36,7 +36,14 @@ export const validatePublicKey = (publicKey: string) => {
 	return true;
 };
 
+export const isNullByteIncluded = (input: string) =>
+	new RegExp('\\0|\\U00000000').test(input);
+
 export const validateUsername = (username: string) => {
+	if (isNullByteIncluded(username)) {
+		return false;
+	}
+
 	if (username !== username.trim().toLowerCase()) {
 		return false;
 	}
@@ -168,6 +175,3 @@ export const isUnique = (values: ReadonlyArray<string>): boolean => {
 
 	return unique.length === values.length;
 };
-
-export const isNullByteIncluded = (input: string) =>
-	new RegExp('\\0|\\U00000000').test(input);

--- a/packages/lisk-transactions/src/utils/validation/validator.ts
+++ b/packages/lisk-transactions/src/utils/validation/validator.ts
@@ -19,6 +19,7 @@ import * as BigNum from 'browserify-bignum';
 import * as schemas from './schema';
 import {
 	isGreaterThanMaxTransactionId,
+	isNullByteIncluded,
 	isNumberString,
 	validateAddress,
 	validateFee,
@@ -119,6 +120,8 @@ validator.addFormat(
 );
 
 validator.addFormat('username', validateUsername);
+
+validator.addFormat('noNullByte', data => !isNullByteIncluded(data));
 
 validator.addKeyword('uniqueSignedPublicKeys', {
 	type: 'array',

--- a/packages/lisk-transactions/test/utils/validation/validation.ts
+++ b/packages/lisk-transactions/test/utils/validation/validation.ts
@@ -29,6 +29,7 @@ import {
 	isGreaterThanMaxTransactionId,
 	isNumberString,
 	isValidInteger,
+	isNullByteIncluded,
 } from '../../../src/utils/validation/validation';
 
 describe('validation', () => {
@@ -367,6 +368,20 @@ describe('validation', () => {
 
 		it('should return true when negative integer was provided', () => {
 			return expect(isValidInteger(-6)).to.be.true;
+		});
+	});
+
+	describe('#isNullByteIncluded', () => {
+		const nullCharacterList = ['\0', '\x00', '\u0000', '\\U00000000'];
+
+		it('should return false when string was provided', () => {
+			return expect(isNullByteIncluded('1234')).to.be.false;
+		});
+
+		it('should return true using unicode null characters', () => {
+			nullCharacterList.forEach(nullChar => {
+				expect(isNullByteIncluded(`${nullChar} hey :)`)).to.be.true;
+			});
 		});
 	});
 });

--- a/packages/lisk-transactions/test/utils/validation/validation.ts
+++ b/packages/lisk-transactions/test/utils/validation/validation.ts
@@ -372,15 +372,44 @@ describe('validation', () => {
 	});
 
 	describe('#isNullByteIncluded', () => {
-		const nullCharacterList = ['\0', '\x00', '\u0000', '\\U00000000'];
+		const validStrings = [
+			'lorem ipsum',
+			'lorem\u0001 ipsum',
+			'loremU00000001 ipsum',
+			'\u0001',
+			'\x01',
+			'l©rem',
+			'❤',
+		];
 
-		it('should return false when string was provided', () => {
-			return expect(isNullByteIncluded('1234')).to.be.false;
+		 const invalidStrings = [
+			'\0',
+			'\0lorem',
+			'ipsum\0',
+			'lorem\0 ipsum',
+			'\x00',
+			'\x00lorem',
+			'ipsum\x00',
+			'lorem\x00 ipsum',
+			'\u0000',
+			'\u0000lorem',
+			'ipsum\u0000',
+			'lorem\u0000 ipsum',
+			'\\U00000000',
+			'\\U00000000lorem',
+			'ipsum\\U00000000',
+			'lorem\\U00000000 ipsum',
+		];
+
+		it('should return false when valid string was provided', () => {
+			validStrings.forEach(input => {
+				expect(isNullByteIncluded(input)).to.be.false;
+			});
 		});
 
 		it('should return true using unicode null characters', () => {
-			nullCharacterList.forEach(nullChar => {
-				expect(isNullByteIncluded(`${nullChar} hey :)`)).to.be.true;
+			invalidStrings.forEach(input => {
+				expect(isNullByteIncluded(input)).to.be.true;
 			});
 		});
 	});

--- a/packages/lisk-transactions/test/utils/validation/validator.ts
+++ b/packages/lisk-transactions/test/utils/validation/validator.ts
@@ -592,4 +592,47 @@ describe('validator', () => {
 			).to.be.false;
 		});
 	});
+
+	describe('noNullBytes', () => {
+		let validate: ValidateFunction;
+		beforeEach(() => {
+			validate = validator.compile({
+				$merge: {
+					source: { $ref: baseSchemaId },
+					with: {
+						properties: {
+							target: {
+								type: 'string',
+								format: 'noNullByte',
+							},
+						},
+					},
+				},
+			});
+			return Promise.resolve();
+		});
+
+		it('should validate to true when valid string is provided', () => {
+			return expect(
+				validate({
+					target: 'some normal string',
+				}),
+			).to.be.true;
+		});
+
+		it('should validate to true when it is empty', () => {
+			return expect(validate({ target: '' })).to.be.true;
+		});
+
+		it('should validate to false when string with null byte is provided', () => {
+			const nullCharacterList = ['\0', '\x00', '\u0000', '\\U00000000'];
+			nullCharacterList.forEach(nullChar => {
+				expect(
+					validate({
+						target: `${nullChar} hey \x01 :)`,
+					}),
+				).to.be.false;
+			});
+		});
+	});
 });


### PR DESCRIPTION
### What was the problem?
By protocol, Transfer Transaction and Dapp transaction should not allow null character in string field.

### How did I fix it?
Add the same check done as https://github.com/LiskHQ/lisk/commit/5c7e2944383bf369f1343fba62c71e84de6f9664.
Also, added test to check schema validation works.

### How to test it?
`npm t`

### Review checklist

* The PR resolves #1108 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
