### PR TITLE
Multisignature registration sets to pending when signatures missing - Closes #1106 

### DIFF
--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -121,8 +121,7 @@ export abstract class BaseTransaction {
 	protected _id?: string;
 	protected _signature?: string;
 	protected _signSignature?: string;
-
-	private _multisignatureStatus: MultisignatureStatus =
+	protected _multisignatureStatus: MultisignatureStatus =
 		MultisignatureStatus.UNKNOWN;
 
 	public abstract assetToJSON(): object;

--- a/packages/lisk-transactions/src/utils/verify.ts
+++ b/packages/lisk-transactions/src/utils/verify.ts
@@ -157,6 +157,7 @@ export const verifyMultiSignatures = (
 		errors.length === 1 &&
 		errors[0] instanceof TransactionPendingError
 	) {
+
 		return {
 			status: MultisignatureStatus.PENDING,
 			errors,

--- a/packages/lisk-transactions/test/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/test/0_transfer_transaction.ts
@@ -49,7 +49,9 @@ describe('Transfer transaction class', () => {
 		recipient = validTransferAccount[1];
 		storeAccountCacheStub = sandbox.stub(store.account, 'cache');
 		storeAccountGetStub = sandbox.stub(store.account, 'get').returns(sender);
-		storeAccountGetOrDefaultStub = sandbox.stub(store.account, 'getOrDefault').returns(recipient);
+		storeAccountGetOrDefaultStub = sandbox
+			.stub(store.account, 'getOrDefault')
+			.returns(recipient);
 		storeAccountSetStub = sandbox.stub(store.account, 'set');
 	});
 
@@ -104,7 +106,7 @@ describe('Transfer transaction class', () => {
 	describe('#prepare', async () => {
 		it('should call state store', async () => {
 			await validSelfTransferTestTransaction.prepare(store);
-			expect(storeAccountCacheStub).to.have.been.calledOnceWithExactly([
+			expect(storeAccountCacheStub).to.have.been.calledWithExactly([
 				{ address: validSelfTransferTestTransaction.senderId },
 				{ address: validSelfTransferTestTransaction.recipientId },
 			]);

--- a/packages/lisk-transactions/test/1_second_passphrase_transaction.ts
+++ b/packages/lisk-transactions/test/1_second_passphrase_transaction.ts
@@ -130,7 +130,7 @@ describe('Second signature registration transaction class', () => {
 	describe('#prepare', async () => {
 		it('should call state store', async () => {
 			await validTestTransaction.prepare(store);
-			expect(storeAccountCacheStub).to.have.been.calledOnceWithExactly([
+			expect(storeAccountCacheStub).to.have.been.calledWithExactly([
 				{ address: validTestTransaction.senderId },
 			]);
 		});

--- a/packages/lisk-transactions/test/2_delegate_transaction.ts
+++ b/packages/lisk-transactions/test/2_delegate_transaction.ts
@@ -105,7 +105,7 @@ describe('Delegate registration transaction class', () => {
 	describe('#prepare', async () => {
 		it('should call state store', async () => {
 			await validTestTransaction.prepare(store);
-			expect(storeAccountCacheStub).to.have.been.calledOnceWithExactly([
+			expect(storeAccountCacheStub).to.have.been.calledWithExactly([
 				{ address: validTestTransaction.senderId },
 				{ username: validTestTransaction.asset.delegate.username },
 			]);

--- a/packages/lisk-transactions/test/3_vote_transaction.ts
+++ b/packages/lisk-transactions/test/3_vote_transaction.ts
@@ -172,7 +172,7 @@ describe('Vote transaction class', () => {
 	describe('#prepare', async () => {
 		it('should call state store', async () => {
 			await validTestTransaction.prepare(store);
-			expect(storeAccountCacheStub).to.have.been.calledOnceWithExactly([
+			expect(storeAccountCacheStub).to.have.been.calledWithExactly([
 				{ address: validTestTransaction.senderId },
 				{
 					publicKey:

--- a/packages/lisk-transactions/test/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/test/4_multisignature_transaction.ts
@@ -167,7 +167,7 @@ describe('Multisignature transaction class', () => {
 	describe('#prepare', async () => {
 		it('should call state store', async () => {
 			await validTestTransaction.prepare(store);
-			expect(storeAccountCacheStub).to.have.been.calledOnceWithExactly([
+			expect(storeAccountCacheStub).to.have.been.calledWithExactly([
 				{ address: validTestTransaction.senderId },
 			]);
 		});
@@ -318,6 +318,18 @@ describe('Multisignature transaction class', () => {
 			};
 			storeAccountGetStub.returns(invalidSender);
 			const errors = (validTestTransaction as any).applyAsset(store);
+			expect(errors).not.to.be.empty;
+			expect(errors[0].dataPath).to.be.equal('.signatures');
+		});
+
+		it('should return error when transaction signatures missing', async () => {
+			storeAccountGetStub.returns(nonMultisignatureSender);
+			const invalidTransaction = {
+				...validMultisignatureTransaction,
+				signatures: [],
+			};
+			const transaction = new MultisignatureTransaction(invalidTransaction);
+			const errors = (transaction as any).applyAsset(store);
 			expect(errors).not.to.be.empty;
 			expect(errors[0].dataPath).to.be.equal('.signatures');
 		});

--- a/packages/lisk-transactions/test/5_dapp_transaction.ts
+++ b/packages/lisk-transactions/test/5_dapp_transaction.ts
@@ -176,10 +176,10 @@ describe('Dapp transaction class', () => {
 	describe('#prepare', async () => {
 		it('should call state store', async () => {
 			await validTestTransaction.prepare(store);
-			expect(storeAccountCacheStub).to.have.been.calledOnceWithExactly([
+			expect(storeAccountCacheStub).to.have.been.calledWithExactly([
 				{ address: validTestTransaction.senderId },
 			]);
-			expect(storeTransactionCacheStub).to.have.been.calledOnceWithExactly([
+			expect(storeTransactionCacheStub).to.have.been.calledWithExactly([
 				{ dapp_name: validTestTransaction.asset.dapp.name },
 				{ dapp_link: validTestTransaction.asset.dapp.link },
 			]);


### PR DESCRIPTION
### What was the problem?

Type 4 multisig registration transactions were not checking transaction signatures and properly setting to pending if missing.

### How did I fix it?

Added check and verification of transaction signatures in `apply` stage for multisig transactions. 

### How to test it?

npm test

### Review checklist

* The PR resolves #1106 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
