### PR TITLE
Make sure that all P2PNodeInfo/peerHeaders has an options object to support custom properties - Closes #1115

### DIFF
--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -56,12 +56,14 @@ import {
 	EVENT_CONNECT_ABORT_OUTBOUND,
 	EVENT_CONNECT_OUTBOUND,
 	EVENT_DISCOVERED_PEER,
+	EVENT_FAILED_PEER_INFO_UPDATE,
 	EVENT_FAILED_TO_FETCH_PEER_INFO,
 	EVENT_FAILED_TO_PUSH_NODE_INFO,
 	EVENT_INBOUND_SOCKET_ERROR,
 	EVENT_MESSAGE_RECEIVED,
 	EVENT_OUTBOUND_SOCKET_ERROR,
 	EVENT_REQUEST_RECEIVED,
+	EVENT_UPDATED_PEER_INFO,
 	PeerPool,
 } from './peer_pool';
 
@@ -76,6 +78,8 @@ export {
 	EVENT_MESSAGE_RECEIVED,
 	EVENT_OUTBOUND_SOCKET_ERROR,
 	EVENT_INBOUND_SOCKET_ERROR,
+	EVENT_UPDATED_PEER_INFO,
+	EVENT_FAILED_PEER_INFO_UPDATE,
 };
 
 export const EVENT_NEW_INBOUND_PEER = 'newInboundPeer';
@@ -108,6 +112,8 @@ export class P2P extends EventEmitter {
 	private readonly _handlePeerConnect: (peerInfo: P2PPeerInfo) => void;
 	private readonly _handlePeerConnectAbort: (peerInfo: P2PPeerInfo) => void;
 	private readonly _handlePeerClose: (closePacket: P2PClosePacket) => void;
+	private readonly _handlePeerInfoUpdate: (peerInfo: P2PDiscoveredPeerInfo) => void;
+	private readonly _handleFailedPeerInfoUpdate: (error: Error) => void;
 	private readonly _handleOutboundSocketError: (error: Error) => void;
 	private readonly _handleInboundSocketError: (error: Error) => void;
 
@@ -150,6 +156,16 @@ export class P2P extends EventEmitter {
 		this._handlePeerClose = (closePacket: P2PClosePacket) => {
 			// Re-emit the message to allow it to bubble up the class hierarchy.
 			this.emit(EVENT_CLOSE_OUTBOUND, closePacket);
+		};
+
+		this._handlePeerInfoUpdate = (peerInfo: P2PPeerInfo) => {
+			// Re-emit the message to allow it to bubble up the class hierarchy.
+			this.emit(EVENT_UPDATED_PEER_INFO, peerInfo);
+		};
+
+		this._handleFailedPeerInfoUpdate = (error: Error) => {
+			// Re-emit the message to allow it to bubble up the class hierarchy.
+			this.emit(EVENT_FAILED_PEER_INFO_UPDATE, error);
 		};
 
 		this._handleDiscoveredPeer = (detailedPeerInfo: P2PDiscoveredPeerInfo) => {
@@ -447,6 +463,8 @@ export class P2P extends EventEmitter {
 		peerPool.on(EVENT_CONNECT_OUTBOUND, this._handlePeerConnect);
 		peerPool.on(EVENT_CONNECT_ABORT_OUTBOUND, this._handlePeerConnectAbort);
 		peerPool.on(EVENT_CLOSE_OUTBOUND, this._handlePeerClose);
+		peerPool.on(EVENT_UPDATED_PEER_INFO, this._handlePeerInfoUpdate);
+		peerPool.on(EVENT_FAILED_PEER_INFO_UPDATE, this._handleFailedPeerInfoUpdate);
 		peerPool.on(
 			EVENT_DISCOVERED_PEER,
 			this._handleDiscoveredPeer,

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -115,6 +115,7 @@ export interface ProtocolPeerInfo {
 	readonly os?: string;
 	readonly version: string;
 	readonly wsPort: number;
+	readonly httpPort?: number;
 	readonly options?: P2PInfoOptions;
 }
 

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -422,7 +422,6 @@ export class PeerPool extends EventEmitter {
 		// TODO later: Remove fields that are specific to the current Lisk protocol.
 		const protocolPeerInfoList: ProtocolPeerInfoList = {
 			success: true,
-			// TODO ASAP: We need a new type to account for complete P2PPeerInfo which has all possible fields (e.g. P2PDiscoveredPeerInfo) that way we don't need to have all these checks below.
 			peers: this._pickRandomDiscoveredPeers(MAX_PEER_LIST_BATCH_SIZE)
 				.map(
 					(peer: Peer): ProtocolPeerInfo | undefined => {
@@ -433,6 +432,7 @@ export class PeerPool extends EventEmitter {
 							return undefined;
 						}
 
+						// The options property is not read by the current legacy protocol but it should be added anyway for future compatibility.
 						return {
 							broadhash: peerDetailedInfo.options
 								? (peerDetailedInfo.options.broadhash as string)
@@ -444,7 +444,10 @@ export class PeerPool extends EventEmitter {
 								: '',
 							os: peerDetailedInfo.os,
 							version: peerDetailedInfo.version,
-							wsPort: peerDetailedInfo.wsPort
+							httpPort: peerDetailedInfo.options
+								? (peerDetailedInfo.options.httpPort as number) : undefined,
+							wsPort: peerDetailedInfo.wsPort,
+							options: peerDetailedInfo.options
 						};
 					},
 				)

--- a/packages/lisk-p2p/src/validation.ts
+++ b/packages/lisk-p2p/src/validation.ts
@@ -47,27 +47,6 @@ export const validatePeerAddress = (ip: string, wsPort: number): boolean => {
 	return true;
 };
 
-export const validateStatusProtocolPeerInfo = (
-	rawPeerInfo: unknown,
-): ProtocolPeerInfo => {
-	if (!rawPeerInfo) {
-		throw new InvalidPeerError(`Invalid peer object`);
-	}
-
-	const protocolPeer = rawPeerInfo as ProtocolPeerInfo;
-	if (
-		!protocolPeer.wsPort
-	) {
-		throw new InvalidPeerError(`Invalid peer ip or port`);
-	}
-
-	if (!protocolPeer.version || !isValidVersion(protocolPeer.version)) {
-		throw new InvalidPeerError(`Invalid peer version`);
-	}
-
-	return protocolPeer;
-};
-
 export const validatePeerInfo = (
 	rawPeerInfo: unknown,
 ): P2PDiscoveredPeerInfo => {

--- a/packages/lisk-p2p/src/validation.ts
+++ b/packages/lisk-p2p/src/validation.ts
@@ -81,7 +81,12 @@ export const validatePeerInfo = (
 		height,
 		os,
 		version,
-		options: protocolPeer,
+		options: {
+			httpPort: protocolPeer.httpPort,
+			broadhash: protocolPeer.broadhash,
+			nonce: protocolPeer.nonce,
+			...protocolPeer.options
+		},
 		isDiscoveredPeer: true,
 	};
 

--- a/packages/lisk-p2p/test/unit/validation.ts
+++ b/packages/lisk-p2p/test/unit/validation.ts
@@ -231,7 +231,12 @@ describe('response handlers', () => {
 				peer.wsPort = +peer.wsPort;
 				peer.height = +peer.height;
 				peer.isDiscoveredPeer = true;
-				peer.options = peer;
+				peer.options = {
+					broadhash: peer.broadhash,
+					httpPort: peer.httpPort,
+					nonce: peer.nonce,
+					...peer.options
+				};
 				delete peer.ip;
 
 				return peer;


### PR DESCRIPTION
### What was the problem?

- The options object was not constructed properly in some parts of the code when receiving peer info.
- One of the validation functions turned out to be unnecessary.
- When converting the node info into the legacy protocol format, we were not adding the options property; this is necessary to allow the node to pass custom fields to peers.

### How did I fix it?

- Added missing options fields where required and improved how the options object is constructed.
- Reused validation functionality where possible when handling inbound peer info; we did not need a separate function.
- Exposed new events from the peer which were not being used before.

### How to test it?

```
npm run test
```

### Review checklist

* The PR resolves #1115
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
