### PR TITLE
Allow custom peer selection function to be passed and used in P2P - Closes#1113

### DIFF
--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -43,6 +43,7 @@ import {
 	P2PNetworkStatus,
 	P2PNodeInfo,
 	P2PPeerInfo,
+	P2PPeerSelectionFunctions,
 	P2PPenalty,
 	P2PRequestPacket,
 	P2PResponsePacket,
@@ -117,7 +118,7 @@ export class P2P extends EventEmitter {
 	private readonly _handleOutboundSocketError: (error: Error) => void;
 	private readonly _handleInboundSocketError: (error: Error) => void;
 
-	public constructor(config: P2PConfig) {
+	public constructor(config: P2PConfig, peerSelectionFunction?: P2PPeerSelectionFunctions) {
 		super();
 		this._config = config;
 		this._isActive = false;
@@ -200,7 +201,8 @@ export class P2P extends EventEmitter {
 		this._peerPool = new PeerPool({
 			connectTimeout: this._config.connectTimeout,
 			ackTimeout: this._config.ackTimeout,
-		});
+		}, peerSelectionFunction);
+
 		this._bindHandlersToPeerPool(this._peerPool);
 
 		this._nodeInfo = config.nodeInfo;

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -82,6 +82,8 @@ export interface P2PConfig {
 	readonly nodeInfo: P2PNodeInfo;
 	readonly wsEngine?: string;
 	readonly discoveryInterval?: number;
+	readonly peerSelectionForSendRequest?: P2PPeerSelectionForSendRequest;
+	readonly peerSelectionForConnection?: P2PPeerSelectionForConnection;
 }
 
 // Network info exposed by the P2P library.
@@ -105,24 +107,16 @@ export interface ProtocolNodeInfo {
 	readonly options?: P2PInfoOptions;
 }
 
-export interface P2PPeerSelectionOptions {
-	readonly [key: string]: string | number;
-}
-
 export type P2PPeerSelectionForSendRequest = (
 	peers: ReadonlyArray<P2PPeerInfo>,
-	selectionParams?: P2PPeerSelectionOptions,
+	nodeInfo?: P2PNodeInfo,
 	numOfPeers?: number,
 ) => ReadonlyArray<P2PPeerInfo>;
 
 export type P2PPeerSelectionForConnection = (
 	peers: ReadonlyArray<P2PPeerInfo>,
+	nodeInfo?: P2PNodeInfo,
 ) => ReadonlyArray<P2PPeerInfo>;
-
-export interface P2PPeerSelectionFunctions {
-	readonly selectForSendRequest: P2PPeerSelectionForSendRequest;
-	readonly selectForConnection?: P2PPeerSelectionForConnection;
-}
 
 // This is a representation of the inbound peer object according to the current protocol.
 // TODO later: Switch to LIP protocol format.

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -68,9 +68,9 @@ export interface P2PNodeInfo {
 }
 
 export interface P2PClosePacket {
-	readonly peerInfo: P2PPeerInfo,
-	readonly code: number,
-	readonly reason?: string,
+	readonly peerInfo: P2PPeerInfo;
+	readonly code: number;
+	readonly reason?: string;
 }
 
 export interface P2PConfig {
@@ -103,6 +103,25 @@ export interface ProtocolNodeInfo {
 	readonly wsPort: number;
 	readonly httpPort: number;
 	readonly options?: P2PInfoOptions;
+}
+
+export interface P2PPeerSelectionOptions {
+	readonly [key: string]: string | number;
+}
+
+export type P2PPeerSelectionForSendRequest = (
+	peers: ReadonlyArray<P2PPeerInfo>,
+	selectionParams?: P2PPeerSelectionOptions,
+	numOfPeers?: number,
+) => ReadonlyArray<P2PPeerInfo>;
+
+export type P2PPeerSelectionForConnection = (
+	peers: ReadonlyArray<P2PPeerInfo>,
+) => ReadonlyArray<P2PPeerInfo>;
+
+export interface P2PPeerSelectionFunctions {
+	readonly peerSelectionFunction: P2PPeerSelectionForSendRequest;
+	readonly selectForConnection?: P2PPeerSelectionForConnection;
 }
 
 // This is a representation of the inbound peer object according to the current protocol.

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -120,7 +120,7 @@ export type P2PPeerSelectionForConnection = (
 ) => ReadonlyArray<P2PPeerInfo>;
 
 export interface P2PPeerSelectionFunctions {
-	readonly peerSelectionFunction: P2PPeerSelectionForSendRequest;
+	readonly selectForSendRequest: P2PPeerSelectionForSendRequest;
 	readonly selectForConnection?: P2PPeerSelectionForConnection;
 }
 

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -106,7 +106,7 @@ export class PeerPool extends EventEmitter {
 		super();
 		this._peerMap = new Map();
 		this._peerPoolConfig = peerPoolConfig;
-		this._peerSelectForSendRequest = peerSelectionFunction ? peerSelectionFunction.peerSelectionFunction : selectPeers;
+		this._peerSelectForSendRequest = peerSelectionFunction ? peerSelectionFunction.selectForSendRequest : selectPeers;
 		this._peerSelectForConnection = peerSelectionFunction ? (peerSelectionFunction.selectForConnection ? peerSelectionFunction.selectForConnection : selectForConnection) : selectForConnection;
 		// This needs to be an arrow function so that it can be used as a listener.
 		this._handlePeerRPC = (request: P2PRequest) => {

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -32,8 +32,6 @@ import {
 	P2PPeerInfo,
 	P2PPeerSelectionForConnection,
 	P2PPeerSelectionForSendRequest,
-	P2PPeerSelectionFunctions,
-	P2PPeerSelectionOptions,
 	P2PRequestPacket,
 	P2PResponsePacket,
 	ProtocolPeerInfo,
@@ -55,10 +53,7 @@ import {
 	REMOTE_RPC_GET_ALL_PEERS_LIST,
 } from './peer';
 import { discoverPeers } from './peer_discovery';
-import {
-	selectForConnection,
-	selectPeers,
-} from './peer_selection';
+import { selectForConnection, selectPeers } from './peer_selection';
 
 export const EVENT_FAILED_TO_PUSH_NODE_INFO = 'failedToPushNodeInfo';
 export const EVENT_DISCOVERED_PEER = 'discoveredPeer';
@@ -79,12 +74,17 @@ export {
 interface PeerPoolConfig {
 	readonly connectTimeout?: number;
 	readonly ackTimeout?: number;
+	readonly peerSelectionForSendRequest?: P2PPeerSelectionForSendRequest;
+	readonly peerSelectionForConnection?: P2PPeerSelectionForConnection;
 }
 
 export const MAX_PEER_LIST_BATCH_SIZE = 100;
 export const MAX_PEER_DISCOVERY_PROBE_SAMPLE_SIZE = 100;
 
-const selectRandomPeerSample = (peerList:ReadonlyArray<Peer>, count: number): ReadonlyArray<Peer> => shuffle(peerList).slice(0, count);
+const selectRandomPeerSample = (
+	peerList: ReadonlyArray<Peer>,
+	count: number,
+): ReadonlyArray<Peer> => shuffle(peerList).slice(0, count);
 
 export class PeerPool extends EventEmitter {
 	private readonly _peerMap: Map<string, Peer>;
@@ -102,12 +102,16 @@ export class PeerPool extends EventEmitter {
 	private readonly _peerSelectForSendRequest: P2PPeerSelectionForSendRequest;
 	private readonly _peerSelectForConnection: P2PPeerSelectionForConnection;
 
-	public constructor(peerPoolConfig: PeerPoolConfig, peerSelectionFunction?: P2PPeerSelectionFunctions) {
+	public constructor(peerPoolConfig: PeerPoolConfig) {
 		super();
 		this._peerMap = new Map();
 		this._peerPoolConfig = peerPoolConfig;
-		this._peerSelectForSendRequest = peerSelectionFunction ? peerSelectionFunction.selectForSendRequest : selectPeers;
-		this._peerSelectForConnection = peerSelectionFunction ? (peerSelectionFunction.selectForConnection ? peerSelectionFunction.selectForConnection : selectForConnection) : selectForConnection;
+		this._peerSelectForSendRequest = peerPoolConfig.peerSelectionForSendRequest
+			? peerPoolConfig.peerSelectionForSendRequest
+			: selectPeers;
+		this._peerSelectForConnection = peerPoolConfig.peerSelectionForConnection
+			? peerPoolConfig.peerSelectionForConnection
+			: selectForConnection;
 		// This needs to be an arrow function so that it can be used as a listener.
 		this._handlePeerRPC = (request: P2PRequest) => {
 			if (request.procedure === REMOTE_RPC_GET_ALL_PEERS_LIST) {
@@ -148,7 +152,7 @@ export class PeerPool extends EventEmitter {
 				detailedPeerInfo = await peer.fetchStatus();
 			} catch (error) {
 				this.emit(EVENT_FAILED_TO_FETCH_PEER_INFO, error);
-				
+
 				return;
 			}
 			this.emit(EVENT_DISCOVERED_PEER, detailedPeerInfo);
@@ -195,16 +199,13 @@ export class PeerPool extends EventEmitter {
 		return this._nodeInfo;
 	}
 
-	public selectPeers(
-		selectionParams: P2PPeerSelectionOptions,
-		numOfPeers?: number,
-	): ReadonlyArray<P2PPeerInfo> {
+	public selectPeers(numOfPeers?: number): ReadonlyArray<P2PPeerInfo> {
 		const listOfPeerInfo = [...this._peerMap.values()].map(
 			(peer: Peer) => peer.peerInfo,
 		);
 		const selectedPeers = this._peerSelectForSendRequest(
 			listOfPeerInfo,
-			selectionParams,
+			this._nodeInfo,
 			numOfPeers,
 		);
 
@@ -214,10 +215,7 @@ export class PeerPool extends EventEmitter {
 	public async requestFromPeer(
 		packet: P2PRequestPacket,
 	): Promise<P2PResponsePacket> {
-		const peerSelectionParams: P2PPeerSelectionOptions = {
-			lastBlockHeight: this._nodeInfo ? this._nodeInfo.height : 0,
-		};
-		const selectedPeer = this.selectPeers(peerSelectionParams, 1);
+		const selectedPeer = this.selectPeers(1);
 
 		if (selectedPeer.length <= 0) {
 			throw new RequestFailError(
@@ -240,10 +238,7 @@ export class PeerPool extends EventEmitter {
 	}
 
 	public sendToPeers(message: P2PMessagePacket): void {
-		const peerSelectionParams: P2PPeerSelectionOptions = {
-			lastBlockHeight: this._nodeInfo ? this._nodeInfo.height : 0,
-		};
-		const selectedPeers = this.selectPeers(peerSelectionParams);
+		const selectedPeers = this.selectPeers();
 
 		selectedPeers.forEach((peerInfo: P2PPeerInfo) => {
 			const selectedPeerId = constructPeerIdFromPeerInfo(peerInfo);
@@ -259,7 +254,6 @@ export class PeerPool extends EventEmitter {
 		knownPeers: ReadonlyArray<P2PPeerInfo>,
 		blacklist: ReadonlyArray<P2PPeerInfo>,
 	): Promise<ReadonlyArray<P2PDiscoveredPeerInfo>> {
-		
 		const peersObjectList = knownPeers.map((peerInfo: P2PPeerInfo) => {
 			const peerId = constructPeerIdFromPeerInfo(peerInfo);
 			if (this.hasPeer(peerId)) {
@@ -282,7 +276,7 @@ export class PeerPool extends EventEmitter {
 		const disoveredPeers = await discoverPeers(peerSampleToProbe, {
 			blacklist: blacklist.map(peer => peer.ipAddress),
 		});
-		
+
 		return disoveredPeers;
 	}
 
@@ -293,7 +287,7 @@ export class PeerPool extends EventEmitter {
 
 		peersToConnect.forEach((peerInfo: P2PPeerInfo) => {
 			const peerId = constructPeerIdFromPeerInfo(peerInfo);
-			if(!this.hasPeer(peerId)) {
+			if (!this.hasPeer(peerId)) {
 				this.addPeer(peerInfo);
 			}
 		});
@@ -433,7 +427,7 @@ export class PeerPool extends EventEmitter {
 					(peer: Peer): ProtocolPeerInfo | undefined => {
 						const peerDetailedInfo: P2PDiscoveredPeerInfo | undefined =
 							peer.detailedPeerInfo;
-						
+
 						if (!peerDetailedInfo) {
 							return undefined;
 						}

--- a/packages/lisk-p2p/src/peer_selection.ts
+++ b/packages/lisk-p2p/src/peer_selection.ts
@@ -13,11 +13,7 @@
  *
  */
 import { NotEnoughPeersError } from './errors';
-import { P2PPeerInfo } from './p2p_types';
-
-export interface PeerOptions {
-	readonly [key: string]: string | number;
-}
+import { P2PPeerInfo, P2PPeerSelectionOptions } from './p2p_types';
 /* tslint:disable: readonly-keyword*/
 interface Histogram {
 	[key: number]: number;
@@ -31,7 +27,7 @@ interface HistogramValues {
 /* tslint:enable: readonly-keyword */
 export const selectPeers = (
 	peers: ReadonlyArray<P2PPeerInfo>,
-	selectionParams: PeerOptions = { lastBlockHeight: 0 },
+	selectionParams: P2PPeerSelectionOptions = { lastBlockHeight: 0 },
 	numOfPeers: number = 0,
 ): ReadonlyArray<P2PPeerInfo> => {
 	const filteredPeers = peers.filter(
@@ -119,5 +115,7 @@ export const selectPeers = (
 	return peerList;
 };
 
-export const selectForConnection = (peerInfoList: ReadonlyArray<P2PPeerInfo>) =>
-	peerInfoList;
+export const selectForConnection = (
+	peerInfoList: ReadonlyArray<P2PPeerInfo>,
+	_selectionOptions?: P2PPeerSelectionOptions,
+) => peerInfoList;

--- a/packages/lisk-p2p/src/peer_selection.ts
+++ b/packages/lisk-p2p/src/peer_selection.ts
@@ -13,7 +13,7 @@
  *
  */
 import { NotEnoughPeersError } from './errors';
-import { P2PPeerInfo, P2PPeerSelectionOptions } from './p2p_types';
+import { P2PNodeInfo, P2PPeerInfo } from './p2p_types';
 /* tslint:disable: readonly-keyword*/
 interface Histogram {
 	[key: number]: number;
@@ -27,12 +27,13 @@ interface HistogramValues {
 /* tslint:enable: readonly-keyword */
 export const selectPeers = (
 	peers: ReadonlyArray<P2PPeerInfo>,
-	selectionParams: P2PPeerSelectionOptions = { lastBlockHeight: 0 },
+	nodeInfo?: P2PNodeInfo,
 	numOfPeers: number = 0,
 ): ReadonlyArray<P2PPeerInfo> => {
+	const nodeHeight = nodeInfo ? nodeInfo.height : 0;
 	const filteredPeers = peers.filter(
 		// Remove unreachable peers or heights below last block height
-		(peer: P2PPeerInfo) => peer.height >= selectionParams.lastBlockHeight,
+		(peer: P2PPeerInfo) => peer.height >= nodeHeight,
 	);
 
 	if (filteredPeers.length === 0) {
@@ -117,5 +118,5 @@ export const selectPeers = (
 
 export const selectForConnection = (
 	peerInfoList: ReadonlyArray<P2PPeerInfo>,
-	_selectionOptions?: P2PPeerSelectionOptions,
+	_nodeInfo?: P2PNodeInfo,
 ) => peerInfoList;

--- a/packages/lisk-p2p/test/unit/peer_selection.ts
+++ b/packages/lisk-p2p/test/unit/peer_selection.ts
@@ -14,16 +14,13 @@
  */
 import { expect } from 'chai';
 import { initializePeerList } from '../utils/peers';
-import {
-	PeerOptions,
-	selectForConnection,
-	selectPeers,
-} from '../../src/peer_selection';
+import { selectForConnection, selectPeers } from '../../src/peer_selection';
+import { P2PPeerSelectionOptions } from '../../src/p2p_types';
 
 describe('peer selector', () => {
 	describe('#selectPeer', () => {
 		let peerList = initializePeerList();
-		const selectionParams: PeerOptions = {
+		const selectionParams: P2PPeerSelectionOptions = {
 			lastBlockHeight: 545777,
 			netHash: '73458irc3yb7rg37r7326dbt7236',
 		};

--- a/packages/lisk-p2p/test/unit/peer_selection.ts
+++ b/packages/lisk-p2p/test/unit/peer_selection.ts
@@ -15,14 +15,17 @@
 import { expect } from 'chai';
 import { initializePeerList } from '../utils/peers';
 import { selectForConnection, selectPeers } from '../../src/peer_selection';
-import { P2PPeerSelectionOptions } from '../../src/p2p_types';
+import { P2PNodeInfo } from '../../src/p2p_types';
 
 describe('peer selector', () => {
 	describe('#selectPeer', () => {
 		let peerList = initializePeerList();
-		const selectionParams: P2PPeerSelectionOptions = {
-			lastBlockHeight: 545777,
-			netHash: '73458irc3yb7rg37r7326dbt7236',
+		const nodeInfo: P2PNodeInfo = {
+			height: 545777,
+			nethash: '73458irc3yb7rg37r7326dbt7236',
+			os: 'linux',
+			version: '1.1.1',
+			wsPort: 5000,
 		};
 
 		describe('get a list of n number of good peers', () => {
@@ -35,55 +38,53 @@ describe('peer selector', () => {
 			});
 
 			it('should return an array', () => {
-				return expect(selectPeers(peerList, selectionParams)).to.be.an('array');
+				return expect(selectPeers(peerList, nodeInfo)).to.be.an('array');
 			});
 
 			it('returned array should contain good peers according to algorithm', () => {
-				return expect(selectPeers(peerList, selectionParams))
+				return expect(selectPeers(peerList, nodeInfo))
 					.and.be.an('array')
 					.and.of.length(3);
 			});
 
 			it('return empty peer list for no peers as an argument', () => {
-				return expect(selectPeers([], selectionParams))
+				return expect(selectPeers([], nodeInfo))
 					.and.be.an('array')
 					.and.to.be.eql([]);
 			});
 
 			it('should return an array having one good peer', () => {
-				return expect(selectPeers(peerList, selectionParams, 1))
+				return expect(selectPeers(peerList, nodeInfo, 1))
 					.and.be.an('array')
 					.and.of.length(1);
 			});
 
 			it('should return an array having 2 good peers', () => {
-				return expect(selectPeers(peerList, selectionParams, 2))
+				return expect(selectPeers(peerList, nodeInfo, 2))
 					.and.be.an('array')
 					.and.of.length(2);
 			});
 
 			it('should return an array having all good peers', () => {
-				return expect(selectPeers(peerList, selectionParams, 0))
+				return expect(selectPeers(peerList, nodeInfo, 0))
 					.and.be.an('array')
 					.and.of.length(3);
 			});
 
 			it('should return an array having all good peers ignoring requested negative number of peers', () => {
-				return expect(selectPeers(peerList, selectionParams, -1))
+				return expect(selectPeers(peerList, nodeInfo, -1))
 					.and.be.an('array')
 					.and.of.length(3);
 			});
 
 			it('should return an array of equal length equal to requested number of peers', () => {
-				return expect(selectPeers(peerList, selectionParams, 3))
+				return expect(selectPeers(peerList, nodeInfo, 3))
 					.and.be.an('array')
 					.and.of.length(3);
 			});
 
 			it('should throw an error when requested peers are greater than available good peers', () => {
-				return expect(
-					selectPeers.bind(selectPeers, peerList, selectionParams, 4),
-				)
+				return expect(selectPeers.bind(selectPeers, peerList, nodeInfo, 4))
 					.to.throw(
 						`Requested number of peers: '4' is more than the available number of good peers: '3'`,
 					)
@@ -97,11 +98,11 @@ describe('peer selector', () => {
 				peerList = initializePeerList();
 			});
 			const lowHeightPeers = peerList.filter(
-				peer => peer.height < selectionParams.lastBlockHeight,
+				peer => peer.height < nodeInfo.height,
 			);
 
 			it('should return an array with 0 good peers', () => {
-				return expect(selectPeers(lowHeightPeers, selectionParams, 2))
+				return expect(selectPeers(lowHeightPeers, nodeInfo, 2))
 					.and.be.an('array')
 					.and.of.length(0);
 			});


### PR DESCRIPTION
### Description

With the introduction of custom Peer Selection function, a user could pass and use P2P library with its own Peer Selection algorithm based on its preferred custom parameters. Below are the changes,

* Allow P2P to accept custom peer selection algorithm that will be used for send/request and also peer selection for connection in PeerPool, hence initialize PeerPool constructor by passing this custom Peer Selection function. 

* Based on P2P class change, introduce new type definition for peer selection function and arguments that will be available to user as well.

* Modify PeerPool constructor to accept peer selection functions as argument, if undefined then use default ones

* Make default peer selection algorithm to use type definition from `p2p_types.ts` to have consistency.

* Add an argument to `selectForConnection` function to accept `selectionParams` so that in future it could be modified as well to accept custom params for selection.

* Update peer selection tests

### Review checklist

* The PR resolves #1113  
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
