### PR TITLE
Add scenarios in integration tests relevant to lisk-p2p

### DIFF
--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -282,8 +282,8 @@ describe('Integration tests for P2P library', () => {
 			});
 
 			describe('P2P.send when peers are at different heights', () => {
-				let collectedMessages: Array<any> = [];
 				const randomPeerIndex = Math.floor(Math.random() * NETWORK_PEER_COUNT);
+				let collectedMessages: Array<any> = [];
 				let randomP2PNode: any;
 
 				beforeEach(async () => {
@@ -301,8 +301,8 @@ describe('Integration tests for P2P library', () => {
 
 				it('should send messages to subset of peers within the network with updated heights; should reach multiple peers with even distribution', async () => {
 					const TOTAL_SENDS = 100;
-
 					const nodePortToMessagesMap: any = {};
+
 					p2pNodeList.forEach(p2p => {
 						p2p.applyNodeInfo({
 							os: platform(),
@@ -314,6 +314,7 @@ describe('Integration tests for P2P library', () => {
 							options: p2p.nodeInfo.options,
 						});
 					});
+
 					await wait(200);
 
 					const expectedAverageMessagesPerNode = TOTAL_SENDS;

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -10,6 +10,7 @@ describe('Integration tests for P2P library', () => {
 		...Array(NETWORK_PEER_COUNT).keys(),
 	].map(index => NETWORK_START_PORT + index);
 	const NETWORK_END_PORT = ALL_NODE_PORTS[ALL_NODE_PORTS.length - 1];
+	const NO_PEERS_FOUND_ERROR = `Request failed due to no peers found in peer selection`;
 
 	let p2pNodeList: ReadonlyArray<P2P> = [];
 
@@ -56,6 +57,18 @@ describe('Integration tests for P2P library', () => {
 		it('should set the isActive property to true for all nodes', () => {
 			p2pNodeList.forEach(p2p => {
 				expect(p2p).to.have.property('isActive', true);
+			});
+		});
+
+		describe('P2P.request', () => {
+			it('should throw an error when not able to get any peer in peer selection', async () => {
+				const firstP2PNode = p2pNodeList[0];
+				const response = firstP2PNode.request({
+					procedure: 'foo',
+					data: 'bar',
+				});
+
+				expect(response).to.be.rejectedWith(Error, NO_PEERS_FOUND_ERROR);
 			});
 		});
 	});
@@ -198,9 +211,11 @@ describe('Integration tests for P2P library', () => {
 				await wait(DISCOVERY_INTERVAL * 5);
 
 				p2pNodeList.forEach(p2p => {
-					let {connectedPeers} = p2p.getNetworkStatus();
+					let { connectedPeers } = p2p.getNetworkStatus();
 
-					const peerPorts = connectedPeers.map(peerInfo => peerInfo.wsPort).sort();
+					const peerPorts = connectedPeers
+						.map(peerInfo => peerInfo.wsPort)
+						.sort();
 					const expectedPeerPorts = ALL_NODE_PORTS;
 
 					expect(peerPorts).to.be.eql(expectedPeerPorts);

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -46,11 +46,9 @@ describe('Integration tests for P2P library', () => {
 
 		afterEach(async () => {
 			await Promise.all(
-				p2pNodeList.map(async p2p => {
-					if (p2p.isActive) {
-						await p2p.stop();
-					}
-				}),
+				p2pNodeList
+					.filter(p2p => p2p.isActive)
+					.map(async p2p => await p2p.stop()),
 			);
 		});
 
@@ -115,11 +113,9 @@ describe('Integration tests for P2P library', () => {
 
 		afterEach(async () => {
 			await Promise.all(
-				p2pNodeList.map(async p2p => {
-					if (p2p.isActive) {
-						await p2p.stop();
-					}
-				}),
+				p2pNodeList
+					.filter(p2p => p2p.isActive)
+					.map(async p2p => await p2p.stop()),
 			);
 		});
 
@@ -197,11 +193,9 @@ describe('Integration tests for P2P library', () => {
 
 		afterEach(async () => {
 			await Promise.all(
-				p2pNodeList.map(async p2p => {
-					if (p2p.isActive) {
-						await p2p.stop();
-					}
-				}),
+				p2pNodeList
+					.filter(p2p => p2p.isActive)
+					.map(async p2p => await p2p.stop()),
 			);
 		});
 
@@ -211,7 +205,7 @@ describe('Integration tests for P2P library', () => {
 				await wait(DISCOVERY_INTERVAL * 5);
 
 				p2pNodeList.forEach(p2p => {
-					let { connectedPeers } = p2p.getNetworkStatus();
+					const { connectedPeers } = p2p.getNetworkStatus();
 
 					const peerPorts = connectedPeers
 						.map(peerInfo => peerInfo.wsPort)
@@ -357,29 +351,33 @@ describe('Integration tests for P2P library', () => {
 				const firstP2PNode = p2pNodeList[0];
 				// Stop all the nodes with port from 5001 to 5005
 				p2pNodeList.forEach(async (p2p: any, index: number) => {
-					if (index !== 0 && index < NETWORK_PEER_COUNT/2) {
+					if (index !== 0 && index < NETWORK_PEER_COUNT / 2) {
 						await p2p.stop();
 					}
 				});
 				await wait(200);
 
 				const connectedPeers = firstP2PNode.getNetworkStatus().connectedPeers;
-				const portOfLastInactivePort = ALL_NODE_PORTS[NETWORK_PEER_COUNT / 2 ];
+				const portOfLastInactivePort = ALL_NODE_PORTS[NETWORK_PEER_COUNT / 2];
 
 				const actualConnectedPeers = connectedPeers
-					.filter((peer) => peer.wsPort !== 5000 && (peer.wsPort % 5000) > NETWORK_PEER_COUNT / 2)
-					.map((peer) => peer.wsPort);
+					.filter(
+						peer =>
+							peer.wsPort !== 5000 &&
+							peer.wsPort % 5000 > NETWORK_PEER_COUNT / 2,
+					)
+					.map(peer => peer.wsPort);
 
 				// Check if the connected Peers are having port greater than the last port that we crashed by index
-				actualConnectedPeers.forEach((port) => {
-					expect(port).greaterThan(portOfLastInactivePort)
+				actualConnectedPeers.forEach(port => {
+					expect(port).greaterThan(portOfLastInactivePort);
 				});
 
-				p2pNodeList.forEach((p2p) => {
+				p2pNodeList.forEach(p2p => {
 					if (p2p.nodeInfo.wsPort > portOfLastInactivePort) {
 						expect(p2p.isActive).to.be.true;
 					}
-				})
+				});
 			});
 		});
 	});
@@ -431,12 +429,9 @@ describe('Integration tests for P2P library', () => {
 
 		afterEach(async () => {
 			await Promise.all(
-				p2pNodeList.map(p2p => {
-					if (p2p.isActive) {
-						return p2p.stop();
-					}
-					return;
-				}),
+				p2pNodeList
+					.filter(p2p => p2p.isActive)
+					.map(async p2p => await p2p.stop()),
 			);
 			await wait(100);
 		});


### PR DESCRIPTION
### Description

Add missing integration tests on lisk-p2p. Cover different scenarios like, for example, when a couple of nodes become unresponsive due to some reason, other nodes connected should be able to detect and update their network status gracefully. 

### Review checklist

* The PR resolves #INSERT_ISSUE_NUMBER
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
