### PR TITLE
Multisignature transaction should update the memberPublicKeys property for account - Closes #1125

### DIFF
--- a/packages/lisk-transactions/fixtures/valid_multisignature_account.json
+++ b/packages/lisk-transactions/fixtures/valid_multisignature_account.json
@@ -5,7 +5,7 @@
 	"balance": "94378900000",
 	"multimin": 2,
 	"multilifetime": 1,
-	"multisignatures": [
+	"membersPublicKeys": [
 		"40af643265a718844f3dac56ce17ae1d7d47d0a24a35a277a0a6cb0baaa1939f",
 		"d042ad3f1a5b042ddc5aa80c4267b5bfd3b4dda3a682da0a3ef7269409347adb",
 		"542fdc008964eacc580089271353268d655ab5ec2829687aadc278653fad33cf"

--- a/packages/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/src/4_multisignature_transaction.ts
@@ -232,7 +232,7 @@ export class MultisignatureTransaction extends BaseTransaction {
 		const sender = store.account.get(this.senderId);
 
 		// Check if multisignatures already exists on account
-		if (sender.multisignatures && sender.multisignatures.length > 0) {
+		if (sender.membersPublicKeys && sender.membersPublicKeys.length > 0) {
 			errors.push(
 				new TransactionError(
 					'Register multisignature only allowed once per account.',
@@ -255,7 +255,7 @@ export class MultisignatureTransaction extends BaseTransaction {
 
 		const updatedSender = {
 			...sender,
-			multisignatures: this.asset.multisignature.keysgroup.map(key =>
+			membersPublicKeys: this.asset.multisignature.keysgroup.map(key =>
 				key.substring(1),
 			),
 			multimin: this.asset.multisignature.min,
@@ -289,7 +289,7 @@ export class MultisignatureTransaction extends BaseTransaction {
 		const sender = store.account.get(this.senderId);
 
 		const {
-			multisignatures,
+			membersPublicKeys,
 			multimin,
 			multilifetime,
 			...strippedSender

--- a/packages/lisk-transactions/src/transaction_types.ts
+++ b/packages/lisk-transactions/src/transaction_types.ts
@@ -20,7 +20,7 @@ export interface Account {
 	readonly delegate?: Delegate;
 	readonly publicKey?: string;
 	readonly secondPublicKey?: string;
-	readonly multisignatures?: ReadonlyArray<string>;
+	readonly membersPublicKeys?: ReadonlyArray<string>;
 	readonly multimin?: number;
 	readonly multilifetime?: number;
 	readonly username?: string;

--- a/packages/lisk-transactions/src/utils/verify.ts
+++ b/packages/lisk-transactions/src/utils/verify.ts
@@ -126,8 +126,8 @@ interface VerifyMultiSignatureResult {
 
 const isMultisignatureAccount = (account: Account): boolean =>
 	!!(
-		account.multisignatures &&
-		account.multisignatures.length > 0 &&
+		account.membersPublicKeys &&
+		account.membersPublicKeys.length > 0 &&
 		account.multimin
 	);
 
@@ -158,7 +158,7 @@ export const verifyMultiSignatures = (
 	}
 
 	const { valid, errors } = validateMultisignatures(
-		sender.multisignatures as ReadonlyArray<string>,
+		sender.membersPublicKeys as ReadonlyArray<string>,
 		signatures,
 		sender.multimin as number,
 		transactionBytes,
@@ -177,7 +177,6 @@ export const verifyMultiSignatures = (
 		errors.length === 1 &&
 		errors[0] instanceof TransactionPendingError
 	) {
-
 		return {
 			status: MultisignatureStatus.PENDING,
 			errors,

--- a/packages/lisk-transactions/test/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/test/4_multisignature_transaction.ts
@@ -29,7 +29,7 @@ describe('Multisignature transaction class', () => {
 		validMultisignatureRegistrationTransaction,
 	);
 	const {
-		multisignatures,
+		membersPublicKeys,
 		multilifetime,
 		multimin,
 		...nonMultisignatureAccount
@@ -311,8 +311,8 @@ describe('Multisignature transaction class', () => {
 		it('should return error when keysgroup includes sender key', async () => {
 			const invalidSender = {
 				...multisignatureSender,
-				multisignatures: [
-					...(multisignatureSender as any).multisignatures,
+				membersPublicKeys: [
+					...(multisignatureSender as any).membersPublicKeys,
 					multisignatureSender.publicKey,
 				],
 			};

--- a/packages/lisk-transactions/test/utils/sign_and_validate.ts
+++ b/packages/lisk-transactions/test/utils/sign_and_validate.ts
@@ -157,7 +157,7 @@ describe('signAndVerify module', () => {
 		);
 
 		const {
-			multisignatures: memberPublicKeys,
+			membersPublicKeys: memberPublicKeys,
 		} = defaultMultisignatureAccount as Account;
 
 		it('should return a valid response with valid signatures', async () => {

--- a/packages/lisk-transactions/test/utils/verify.ts
+++ b/packages/lisk-transactions/test/utils/verify.ts
@@ -194,7 +194,7 @@ describe('#verify', () => {
 	describe('#verifyMultiSignatures', () => {
 		const defaultAccount = {
 			address: '123L',
-			multisignatures: [
+			membersPublicKeys: [
 				'c465d74511c2bfd136cf9764172acd3c1514fa7ad76475e03bc91cf679757a5a',
 				'c465d74511c2bfd136cf9764172acd3c1514fa7ad76475e03bc91cf679757a5b',
 				'c465d74511c2bfd136cf9764172acd3c1514fa7ad76475e03bc91cf679757a5c',
@@ -252,7 +252,7 @@ describe('#verify', () => {
 				fakeTransactionBuffer,
 			);
 			expect(validator.validateMultisignatures).to.be.calledWithExactly(
-				defaultAccount.multisignatures,
+				defaultAccount.membersPublicKeys,
 				signatures,
 				defaultAccount.multimin,
 				fakeTransactionBuffer,


### PR DESCRIPTION
### What was the problem?

- Wrong property name was being used for multisignatures

### How did I fix it?

- It was changed to membersPublicKeys

### How to test it?

- Run tests

### Review checklist

* The PR resolves #1125
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
