### PR TITLE
Vote transaction should update the votedDelegatesPublicKeys property for account - Closes #1128

### DIFF
--- a/packages/lisk-transactions/src/3_vote_transaction.ts
+++ b/packages/lisk-transactions/src/3_vote_transaction.ts
@@ -277,7 +277,7 @@ export class VoteTransaction extends BaseTransaction {
 				);
 			}
 		});
-		const senderVotes = sender.votes || [];
+		const senderVotes = sender.votedDelegatesPublicKeys || [];
 		this.asset.votes.forEach(vote => {
 			const action = vote.charAt(0);
 			const publicKey = vote.substring(1);
@@ -299,7 +299,7 @@ export class VoteTransaction extends BaseTransaction {
 		const unvotes = this.asset.votes
 			.filter(vote => vote.charAt(0) === PREFIX_UNVOTE)
 			.map(vote => vote.substring(1));
-		const originalVotes = sender.votes || [];
+		const originalVotes = sender.votedDelegatesPublicKeys || [];
 		const votedDelegatesPublicKeys: ReadonlyArray<string> = [
 			...originalVotes,
 			...upvotes,
@@ -332,21 +332,24 @@ export class VoteTransaction extends BaseTransaction {
 		const unvotes = this.asset.votes
 			.filter(vote => vote.charAt(0) === PREFIX_UNVOTE)
 			.map(vote => vote.substring(1));
-		const originalVotes = sender.votes || [];
-		const votes: ReadonlyArray<string> = [...originalVotes, ...unvotes].filter(
-			vote => !upvotes.includes(vote),
-		);
-		if (votes.length > MAX_VOTE_PER_ACCOUNT) {
+		const originalVotes = sender.votedDelegatesPublicKeys || [];
+		const votedDelegatesPublicKeys: ReadonlyArray<string> = [
+			...originalVotes,
+			...unvotes,
+		].filter(vote => !upvotes.includes(vote));
+		if (votedDelegatesPublicKeys.length > MAX_VOTE_PER_ACCOUNT) {
 			errors.push(
 				new TransactionError(
-					`Vote cannot exceed ${MAX_VOTE_PER_ACCOUNT} but has ${votes.length}.`,
+					`Vote cannot exceed ${MAX_VOTE_PER_ACCOUNT} but has ${
+						votedDelegatesPublicKeys.length
+					}.`,
 					this.id,
 				),
 			);
 		}
 		const updatedSender = {
 			...sender,
-			votes,
+			votedDelegatesPublicKeys,
 		};
 		store.account.set(updatedSender.address, updatedSender);
 

--- a/packages/lisk-transactions/src/3_vote_transaction.ts
+++ b/packages/lisk-transactions/src/3_vote_transaction.ts
@@ -300,20 +300,23 @@ export class VoteTransaction extends BaseTransaction {
 			.filter(vote => vote.charAt(0) === PREFIX_UNVOTE)
 			.map(vote => vote.substring(1));
 		const originalVotes = sender.votes || [];
-		const votes: ReadonlyArray<string> = [...originalVotes, ...upvotes].filter(
-			vote => !unvotes.includes(vote),
-		);
-		if (votes.length > MAX_VOTE_PER_ACCOUNT) {
+		const votedDelegatesPublicKeys: ReadonlyArray<string> = [
+			...originalVotes,
+			...upvotes,
+		].filter(vote => !unvotes.includes(vote));
+		if (votedDelegatesPublicKeys.length > MAX_VOTE_PER_ACCOUNT) {
 			errors.push(
 				new TransactionError(
-					`Vote cannot exceed ${MAX_VOTE_PER_ACCOUNT} but has ${votes.length}.`,
+					`Vote cannot exceed ${MAX_VOTE_PER_ACCOUNT} but has ${
+						votedDelegatesPublicKeys.length
+					}.`,
 					this.id,
 				),
 			);
 		}
 		const updatedSender = {
 			...sender,
-			votes,
+			votedDelegatesPublicKeys,
 		};
 		store.account.set(updatedSender.address, updatedSender);
 

--- a/packages/lisk-transactions/src/transaction_types.ts
+++ b/packages/lisk-transactions/src/transaction_types.ts
@@ -24,7 +24,7 @@ export interface Account {
 	readonly multimin?: number;
 	readonly multilifetime?: number;
 	readonly username?: string;
-	readonly votes?: ReadonlyArray<string>;
+	readonly votedDelegatesPublicKeys?: ReadonlyArray<string>;
 	readonly isDelegate?: boolean;
 }
 

--- a/packages/lisk-transactions/test/3_vote_transaction.ts
+++ b/packages/lisk-transactions/test/3_vote_transaction.ts
@@ -32,7 +32,9 @@ describe('Vote transaction class', () => {
 		balance: '100000000',
 		publicKey:
 			'30c07dbb72b41e3fda9f29e1a4fc0fce893bb00788515a5e6f50b80312e2f483',
-		votes: ['5a82f58bf35ef4bdfac9a371a64e91914519af31a5cf64a5b8b03ca7d32c15dc'],
+		votedDelegatesPublicKeys: [
+			'5a82f58bf35ef4bdfac9a371a64e91914519af31a5cf64a5b8b03ca7d32c15dc',
+		],
 	};
 
 	const defaultValidDependentAccounts = [
@@ -303,7 +305,7 @@ describe('Vote transaction class', () => {
 				{
 					...defaultValidSender,
 					votedDelegatesPublicKeys: [
-						...defaultValidSender.votes,
+						...defaultValidSender.votedDelegatesPublicKeys,
 						'473c354cdf627b82e9113e02a337486dd3afc5615eb71ffd311c5a0beda37b8c',
 					],
 				},
@@ -330,7 +332,7 @@ describe('Vote transaction class', () => {
 				balance: '100000000',
 				publicKey:
 					'30c07dbb72b41e3fda9f29e1a4fc0fce893bb00788515a5e6f50b80312e2f483',
-				votes: [
+				votedDelegatesPublicKeys: [
 					'5a82f58bf35ef4bdfac9a371a64e91914519af31a5cf64a5b8b03ca7d32c15dc',
 					'473c354cdf627b82e9113e02a337486dd3afc5615eb71ffd311c5a0beda37b8c',
 				],
@@ -347,7 +349,7 @@ describe('Vote transaction class', () => {
 				balance: '100000000',
 				publicKey:
 					'30c07dbb72b41e3fda9f29e1a4fc0fce893bb00788515a5e6f50b80312e2f483',
-				votes: generateRandomPublicKeys(101),
+				votedDelegatesPublicKeys: generateRandomPublicKeys(101),
 			};
 			storeAccountGetStub.returns(invalidSender);
 			const errors = (validTestTransaction as any).applyAsset(store);
@@ -364,6 +366,7 @@ describe('Vote transaction class', () => {
 			expect(storeAccountGetStub).to.be.calledWithExactly(
 				validTestTransaction.senderId,
 			);
+
 			expect(storeAccountSetStub).to.be.calledWithExactly(
 				defaultValidSender.address,
 				defaultValidSender,

--- a/packages/lisk-transactions/test/3_vote_transaction.ts
+++ b/packages/lisk-transactions/test/3_vote_transaction.ts
@@ -302,7 +302,7 @@ describe('Vote transaction class', () => {
 				defaultValidSender.address,
 				{
 					...defaultValidSender,
-					votes: [
+					votedDelegatesPublicKeys: [
 						...defaultValidSender.votes,
 						'473c354cdf627b82e9113e02a337486dd3afc5615eb71ffd311c5a0beda37b8c',
 					],


### PR DESCRIPTION
### What was the problem?

Account Votes where being stored in the `votes` property

### How did I fix it?

Changed the `votes` property to `votedDelegatesPublicKeys`

### How to test it?

Build should be green

### Review checklist

* The PR resolves #1128
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
