### PR TITLE
Fix multisignature double check - Closes #1122

### DIFF
--- a/packages/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/src/4_multisignature_transaction.ts
@@ -14,7 +14,6 @@
  */
 import { hexToBuffer } from '@liskhq/lisk-cryptography';
 import * as BigNum from 'browserify-bignum';
-import { TransactionResponse } from '.';
 import {
 	BaseTransaction,
 	MultisignatureStatus,
@@ -27,7 +26,7 @@ import {
 	TransactionMultiError,
 	TransactionPendingError,
 } from './errors';
-import { createResponse, Status } from './response';
+import { createResponse, Status, TransactionResponse } from './response';
 import { TransactionJSON } from './transaction_types';
 import { validateMultisignatures, validator } from './utils';
 


### PR DESCRIPTION
### What was the problem?
`MultisignatureTransaction` was checking the sender account for the keysgroup.

### How did I fix it?
- override processMultisignatures in `MultisignatureTransaction`
- updated test to check processMultisignatures in `MultisignatureTransaction`

### How to test it?
`npm t`

### Review checklist

* The PR resolves #1122
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
