### PR TITLE
Fix account property name - Closes #1140

### DIFF
--- a/packages/lisk-transactions/fixtures/valid_multisignature_account.json
+++ b/packages/lisk-transactions/fixtures/valid_multisignature_account.json
@@ -3,8 +3,8 @@
 	"publicKey": "500660b67a2ade1e2528b7f648feef8f3b46e2f4f90ca7f5439101b5119f309d",
 	"secondPublicKey": "",
 	"balance": "94378900000",
-	"multimin": 2,
-	"multilifetime": 1,
+	"multiMin": 2,
+	"multiLifetime": 1,
 	"membersPublicKeys": [
 		"40af643265a718844f3dac56ce17ae1d7d47d0a24a35a277a0a6cb0baaa1939f",
 		"d042ad3f1a5b042ddc5aa80c4267b5bfd3b4dda3a682da0a3ef7269409347adb",

--- a/packages/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/src/4_multisignature_transaction.ts
@@ -303,8 +303,8 @@ export class MultisignatureTransaction extends BaseTransaction {
 			membersPublicKeys: this.asset.multisignature.keysgroup.map(key =>
 				key.substring(1),
 			),
-			multimin: this.asset.multisignature.min,
-			multilifetime: this.asset.multisignature.lifetime,
+			multiMin: this.asset.multisignature.min,
+			multiLifetime: this.asset.multisignature.lifetime,
 		};
 		store.account.set(updatedSender.address, updatedSender);
 
@@ -316,8 +316,8 @@ export class MultisignatureTransaction extends BaseTransaction {
 
 		const {
 			membersPublicKeys,
-			multimin,
-			multilifetime,
+			multiMin,
+			multiLifetime,
 			...strippedSender
 		} = sender;
 

--- a/packages/lisk-transactions/src/transaction_types.ts
+++ b/packages/lisk-transactions/src/transaction_types.ts
@@ -21,8 +21,8 @@ export interface Account {
 	readonly publicKey?: string;
 	readonly secondPublicKey?: string;
 	readonly membersPublicKeys?: ReadonlyArray<string>;
-	readonly multimin?: number;
-	readonly multilifetime?: number;
+	readonly multiMin?: number;
+	readonly multiLifetime?: number;
 	readonly username?: string;
 	readonly votedDelegatesPublicKeys?: ReadonlyArray<string>;
 	readonly isDelegate?: boolean;

--- a/packages/lisk-transactions/src/utils/verify.ts
+++ b/packages/lisk-transactions/src/utils/verify.ts
@@ -128,7 +128,7 @@ const isMultisignatureAccount = (account: Account): boolean =>
 	!!(
 		account.membersPublicKeys &&
 		account.membersPublicKeys.length > 0 &&
-		account.multimin
+		account.multiMin
 	);
 
 export const verifyMultiSignatures = (
@@ -160,7 +160,7 @@ export const verifyMultiSignatures = (
 	const { valid, errors } = validateMultisignatures(
 		sender.membersPublicKeys as ReadonlyArray<string>,
 		signatures,
-		sender.multimin as number,
+		sender.multiMin as number,
 		transactionBytes,
 		id,
 	);

--- a/packages/lisk-transactions/test/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/test/4_multisignature_transaction.ts
@@ -30,8 +30,8 @@ describe('Multisignature transaction class', () => {
 	);
 	const {
 		membersPublicKeys,
-		multilifetime,
-		multimin,
+		multiLifetime,
+		multiMin,
 		...nonMultisignatureAccount
 	} = validMultisignatureAccount;
 	let validTestTransaction: MultisignatureTransaction;

--- a/packages/lisk-transactions/test/utils/verify.ts
+++ b/packages/lisk-transactions/test/utils/verify.ts
@@ -199,7 +199,7 @@ describe('#verify', () => {
 				'c465d74511c2bfd136cf9764172acd3c1514fa7ad76475e03bc91cf679757a5b',
 				'c465d74511c2bfd136cf9764172acd3c1514fa7ad76475e03bc91cf679757a5c',
 			],
-			multimin: 3,
+			multiMin: 3,
 		};
 		const signatures = [
 			'00ef8fcf4e1815def245ad32d0d0e3e86993a4029c41e8ca1dc2674c9794d31cefc2226ac539dea8049c7085fdcb29768389b96104ac05a0ddabfb8b523af409',
@@ -254,7 +254,7 @@ describe('#verify', () => {
 			expect(validator.validateMultisignatures).to.be.calledWithExactly(
 				defaultAccount.membersPublicKeys,
 				signatures,
-				defaultAccount.multimin,
+				defaultAccount.multiMin,
 				fakeTransactionBuffer,
 				defaultId,
 			);


### PR DESCRIPTION
### What was the problem?
Account property `multimin` and `multilifetime` had to bee camel-case.

### How did I fix it?
Change Account interface to have camel-case for those property

### How to test it?
- check Account interface is correct
- run `npm test`

### Review checklist

* The PR resolves #1140 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
