### PR TITLE
null recipientPublicKey should not fail validation - Closes #1142

### DIFF
--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -152,7 +152,7 @@ export abstract class BaseTransaction {
 		this._fee = new BigNum(rawTransaction.fee);
 		this._id = rawTransaction.id;
 		this.recipientId = rawTransaction.recipientId;
-		this.recipientPublicKey = rawTransaction.recipientPublicKey;
+		this.recipientPublicKey = rawTransaction.recipientPublicKey || '';
 		this.senderId =
 			rawTransaction.senderId ||
 			getAddressFromPublicKey(rawTransaction.senderPublicKey);


### PR DESCRIPTION
### What was the problem?

null recipientPublicKey was failing validation

### How did I fix it?

by setting recipientPublicKey to empty string if null

### How to test it?

- Build should be green
- Transactions generated by lisk.elements 1.0.0 can be passed to the constructors of 2.1 (this is the scenarios in lisk-core currently where tests use lisk elements but core starting to use 2.1.x)

### Review checklist

* The PR resolves #1142 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
