### PR TITLE
Fix fee property not to be set in the constructor - Closes #1144

### DIFF
--- a/packages/lisk-transactions/fixtures/valid_delegate_transaction.json
+++ b/packages/lisk-transactions/fixtures/valid_delegate_transaction.json
@@ -1,18 +1,17 @@
 {
-    "id": "9046966103496425914",
-    "type": 2,
-    "timestamp": 0,
-    "senderPublicKey": "dd786687dd2399605ce8fe70212d078db1a2fc6effba127defb176a004cec6d4",
-    "senderId": "17676438278047402502L",
-    "recipientId": "",
-    "recipientPublicKey": "",
-    "amount": "0",
-    "fee": "0",
-    "signature": "ace469bdbee1524c7d7d8ce1e2d42fa6ec75d1c25a0e9eff67bbaeb25fb2a3d511629aef342288f1bee83a39a608c8e205a903f1963e6bedb8b7d26a29ae2307",
-    "signatures": [],
-    "asset": {
-      "delegate": {
-        "username": "genesis_10"
-      }
+  "id": "8371141882694519315",
+  "type": 2,
+  "timestamp": 85173795,
+  "senderPublicKey": "ce37dbaf8758001efaf229be3f18c88e28f13131c2b0ddef5e0980b3a401b1fa",
+  "senderId": "11160212819235534805L",
+  "recipientId": "",
+  "amount": "0",
+  "fee": "2500000000",
+  "signature": "5c86ce1ef12b6bf310d3206e90dfa289b7899c3cbbda48651e055d3768108f3bd61aeb1f20afcf0d6e3508c9413891fafbc1ce7937b718dfd7aa6be42a83c50a",
+  "signatures": [],
+  "asset": {
+    "delegate": {
+      "username": "0x0"
     }
   }
+}

--- a/packages/lisk-transactions/src/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/0_transfer_transaction.ts
@@ -77,7 +77,6 @@ export class TransferTransaction extends BaseTransaction {
 		}
 
 		this.asset = tx.asset as TransferAsset;
-		this._fee = new BigNum(TRANSFER_FEE);
 	}
 
 	protected assetToBytes(): Buffer {
@@ -182,12 +181,17 @@ export class TransferTransaction extends BaseTransaction {
 	protected applyAsset(store: StateStore): ReadonlyArray<TransactionError> {
 		const errors: TransactionError[] = [];
 		const sender = store.account.get(this.senderId);
-		
-		const balanceError = verifyAmountBalance(this.id, sender, this.amount, this.fee);
-		if(balanceError) {
+
+		const balanceError = verifyAmountBalance(
+			this.id,
+			sender,
+			this.amount,
+			this.fee,
+		);
+		if (balanceError) {
 			errors.push(balanceError);
 		}
-		
+
 		const updatedSenderBalance = new BigNum(sender.balance).sub(this.amount);
 
 		const updatedSender = {

--- a/packages/lisk-transactions/src/1_second_signature_transaction.ts
+++ b/packages/lisk-transactions/src/1_second_signature_transaction.ts
@@ -13,7 +13,6 @@
  *
  */
 import { hash, hexToBuffer, signData } from '@liskhq/lisk-cryptography';
-import * as BigNum from 'browserify-bignum';
 import {
 	BaseTransaction,
 	StateStore,
@@ -87,7 +86,6 @@ export class SecondSignatureTransaction extends BaseTransaction {
 			throw new TransactionMultiError('Invalid field types', tx.id, errors);
 		}
 		this.asset = tx.asset as SecondSignatureAsset;
-		this._fee = new BigNum(SIGNATURE_FEE);
 	}
 
 	protected assetToBytes(): Buffer {

--- a/packages/lisk-transactions/src/2_delegate_transaction.ts
+++ b/packages/lisk-transactions/src/2_delegate_transaction.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import * as BigNum from 'browserify-bignum';
 import {
 	BaseTransaction,
 	StateStore,
@@ -96,7 +95,6 @@ export class DelegateTransaction extends BaseTransaction {
 			]);
 		}
 		this.asset = tx.asset as DelegateAsset;
-		this._fee = new BigNum(DELEGATE_FEE);
 		this.containsUniqueData = true;
 	}
 
@@ -166,6 +164,16 @@ export class DelegateTransaction extends BaseTransaction {
 					'Amount must be zero for delegate registration transaction',
 					this.id,
 					'.amount',
+				),
+			);
+		}
+
+		if (!this.fee.eq(DELEGATE_FEE)) {
+			errors.push(
+				new TransactionError(
+					`Fee must be equal to ${DELEGATE_FEE}`,
+					this.id,
+					'.fee',
 				),
 			);
 		}

--- a/packages/lisk-transactions/src/3_vote_transaction.ts
+++ b/packages/lisk-transactions/src/3_vote_transaction.ts
@@ -13,7 +13,6 @@
  *
  */
 import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
-import * as BigNum from 'browserify-bignum';
 import {
 	BaseTransaction,
 	StateStore,
@@ -94,7 +93,6 @@ export class VoteTransaction extends BaseTransaction {
 			throw new TransactionMultiError('Invalid field types', tx.id, errors);
 		}
 		this.asset = tx.asset as VoteAsset;
-		this._fee = new BigNum(VOTE_FEE);
 		this.containsUniqueData = true;
 	}
 

--- a/packages/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/src/4_multisignature_transaction.ts
@@ -121,9 +121,6 @@ export class MultisignatureTransaction extends BaseTransaction {
 			throw new TransactionMultiError('Invalid field types', tx.id, errors);
 		}
 		this.asset = tx.asset as MultiSignatureAsset;
-		this._fee = new BigNum(MULTISIGNATURE_FEE).mul(
-			this.asset.multisignature.keysgroup.length + 1,
-		);
 	}
 
 	protected assetToBytes(): Buffer {
@@ -198,6 +195,18 @@ export class MultisignatureTransaction extends BaseTransaction {
 					'Amount must be zero for multisignature registration transaction',
 					this.id,
 					'.asset',
+				),
+			);
+		}
+		const expectedFee = new BigNum(MULTISIGNATURE_FEE).mul(
+			this.asset.multisignature.keysgroup.length + 1,
+		);
+		if (!this.fee.eq(expectedFee)) {
+			errors.push(
+				new TransactionError(
+					`Fee must be equal to ${expectedFee.toString()}`,
+					this.id,
+					'.fee',
 				),
 			);
 		}

--- a/packages/lisk-transactions/src/5_dapp_transaction.ts
+++ b/packages/lisk-transactions/src/5_dapp_transaction.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import * as BigNum from 'browserify-bignum';
 import {
 	BaseTransaction,
 	StateStore,
@@ -142,7 +141,6 @@ export class DappTransaction extends BaseTransaction {
 			throw new TransactionMultiError('Invalid field types.', tx.id, errors);
 		}
 		this.asset = tx.asset as DappAsset;
-		this._fee = new BigNum(DAPP_FEE);
 		this.containsUniqueData = true;
 	}
 

--- a/packages/lisk-transactions/src/6_in_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/6_in_transfer_transaction.ts
@@ -86,7 +86,6 @@ export class InTransferTransaction extends BaseTransaction {
 			throw new TransactionMultiError('Invalid field types', tx.id, errors);
 		}
 		this.asset = tx.asset as InTransferAsset;
-		this._fee = new BigNum(IN_TRANSFER_FEE);
 	}
 
 	protected assetToBytes(): Buffer {
@@ -102,11 +101,14 @@ export class InTransferTransaction extends BaseTransaction {
 			},
 		]);
 
-		const dappTransaction = transactions && transactions.length > 0 ? transactions.find(
-			tx =>
-				tx.type === TRANSACTION_DAPP_TYPE &&
-				tx.id === this.asset.inTransfer.dappId,
-		) : undefined;
+		const dappTransaction =
+			transactions && transactions.length > 0
+				? transactions.find(
+						tx =>
+							tx.type === TRANSACTION_DAPP_TYPE &&
+							tx.id === this.asset.inTransfer.dappId,
+				  )
+				: undefined;
 
 		if (dappTransaction) {
 			await store.account.cache([{ id: dappTransaction.senderId as string }]);
@@ -205,13 +207,18 @@ export class InTransferTransaction extends BaseTransaction {
 		}
 		const sender = store.account.get(this.senderId);
 
-		const balanceError = verifyAmountBalance(this.id, sender, this.amount, this.fee);
-		if(balanceError) {
+		const balanceError = verifyAmountBalance(
+			this.id,
+			sender,
+			this.amount,
+			this.fee,
+		);
+		if (balanceError) {
 			errors.push(balanceError);
 		}
 
 		const updatedBalance = new BigNum(sender.balance).sub(this.amount);
-		
+
 		const updatedSender = { ...sender, balance: updatedBalance.toString() };
 
 		store.account.set(updatedSender.address, updatedSender);

--- a/packages/lisk-transactions/src/7_out_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/7_out_transfer_transaction.ts
@@ -94,7 +94,6 @@ export class OutTransferTransaction extends BaseTransaction {
 			throw new TransactionMultiError('Invalid field types', tx.id, errors);
 		}
 		this.asset = tx.asset as OutTransferAsset;
-		this._fee = new BigNum(OUT_TRANSFER_FEE);
 		this.containsUniqueData = true;
 	}
 
@@ -246,11 +245,16 @@ export class OutTransferTransaction extends BaseTransaction {
 
 		const sender = store.account.get(this.senderId);
 
-		const balanceError = verifyAmountBalance(this.id, sender, this.amount, this.fee);
-		if(balanceError) {
+		const balanceError = verifyAmountBalance(
+			this.id,
+			sender,
+			this.amount,
+			this.fee,
+		);
+		if (balanceError) {
 			errors.push(balanceError);
 		}
-		
+
 		const updatedBalance = new BigNum(sender.balance).sub(this.amount);
 
 		const updatedSender = { ...sender, balance: updatedBalance.toString() };

--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -116,8 +116,8 @@ export abstract class BaseTransaction {
 	public readonly type: number;
 	public readonly receivedAt: Date;
 	public readonly containsUniqueData?: boolean;
+	public readonly fee: BigNum;
 
-	protected _fee: BigNum;
 	protected _id?: string;
 	protected _signature?: string;
 	protected _signSignature?: string;
@@ -149,7 +149,7 @@ export abstract class BaseTransaction {
 		}
 
 		this.amount = new BigNum(rawTransaction.amount);
-		this._fee = new BigNum(rawTransaction.fee);
+		this.fee = new BigNum(rawTransaction.fee);
 		this._id = rawTransaction.id;
 		this.recipientId = rawTransaction.recipientId;
 		this.recipientPublicKey = rawTransaction.recipientPublicKey;
@@ -163,14 +163,6 @@ export abstract class BaseTransaction {
 		this.timestamp = rawTransaction.timestamp;
 		this.type = rawTransaction.type;
 		this.receivedAt = rawTransaction.receivedAt || new Date();
-	}
-
-	public get fee(): BigNum {
-		if (!this._fee) {
-			throw new Error('fee is required to be set before use');
-		}
-
-		return this._fee;
 	}
 
 	public get id(): string {

--- a/packages/lisk-transactions/test/2_delegate_transaction.ts
+++ b/packages/lisk-transactions/test/2_delegate_transaction.ts
@@ -46,7 +46,7 @@ describe('Delegate registration transaction class', () => {
 
 		it('should set the delegate asset', async () => {
 			expect(validTestTransaction.asset.delegate).to.be.an('object');
-			expect(validTestTransaction.asset.delegate.username).to.eql('genesis_10');
+			expect(validTestTransaction.asset.delegate.username).to.eql('0x0');
 		});
 
 		it('should throw TransactionMultiError when asset is not valid string', async () => {


### PR DESCRIPTION
### What was the problem?
Constructor was assigning the default fee, but it for genesis block, it was 0 fee

### How did I fix it?
Remove fee assignment in constructor and only validate

### How to test it?
apply genesis block or npm t

### Review checklist

* The PR resolves #1144
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
