### PR TITLE
Dapp transaction should allow type parameter to either be 0 or 1. - Closes #1148

### DIFF
--- a/packages/lisk-transactions/src/5_dapp_transaction.ts
+++ b/packages/lisk-transactions/src/5_dapp_transaction.ts
@@ -91,7 +91,7 @@ export const dappAssetFormatSchema = {
 				type: {
 					type: 'integer',
 					minimum: 0,
-					maximum: 0,
+					maximum: 1,
 				},
 				link: {
 					type: 'string',


### PR DESCRIPTION
### What was the problem?

- dapp.type only accepted 0

### How did I fix it?

- dapp.type accepts 0 & 1

### How to test it?

Build should be green

### Review checklist

* The PR resolves #1148
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
