### PR TITLE
Second signature registration transaction should update secondSignature flag for account - Closes #1147

### DIFF
--- a/packages/lisk-transactions/src/1_second_signature_transaction.ts
+++ b/packages/lisk-transactions/src/1_second_signature_transaction.ts
@@ -200,7 +200,7 @@ export class SecondSignatureTransaction extends BaseTransaction {
 		const updatedSender = {
 			...sender,
 			secondPublicKey: this.asset.signature.publicKey,
-			secondSignature: true,
+			secondSignature: 1,
 		};
 		store.account.set(updatedSender.address, updatedSender);
 
@@ -212,7 +212,7 @@ export class SecondSignatureTransaction extends BaseTransaction {
 		const strippedSender = {
 			...sender,
 			secondPublicKey: undefined,
-			secondSignature: false,
+			secondSignature: 0,
 		};
 
 		store.account.set(strippedSender.address, strippedSender);

--- a/packages/lisk-transactions/src/1_second_signature_transaction.ts
+++ b/packages/lisk-transactions/src/1_second_signature_transaction.ts
@@ -209,8 +209,11 @@ export class SecondSignatureTransaction extends BaseTransaction {
 
 	protected undoAsset(store: StateStore): ReadonlyArray<TransactionError> {
 		const sender = store.account.get(this.senderId);
-		const { secondPublicKey, ...strippedSender } = sender;
-		strippedSender.secondSignature = false;
+		const strippedSender = {
+			...sender,
+			secondPublicKey: undefined,
+			secondSignature: false,
+		};
 
 		store.account.set(strippedSender.address, strippedSender);
 

--- a/packages/lisk-transactions/src/1_second_signature_transaction.ts
+++ b/packages/lisk-transactions/src/1_second_signature_transaction.ts
@@ -200,6 +200,7 @@ export class SecondSignatureTransaction extends BaseTransaction {
 		const updatedSender = {
 			...sender,
 			secondPublicKey: this.asset.signature.publicKey,
+			secondSignature: true,
 		};
 		store.account.set(updatedSender.address, updatedSender);
 
@@ -209,6 +210,8 @@ export class SecondSignatureTransaction extends BaseTransaction {
 	protected undoAsset(store: StateStore): ReadonlyArray<TransactionError> {
 		const sender = store.account.get(this.senderId);
 		const { secondPublicKey, ...strippedSender } = sender;
+		strippedSender.secondSignature = false;
+
 		store.account.set(strippedSender.address, strippedSender);
 
 		return [];

--- a/packages/lisk-transactions/src/1_second_signature_transaction.ts
+++ b/packages/lisk-transactions/src/1_second_signature_transaction.ts
@@ -211,7 +211,8 @@ export class SecondSignatureTransaction extends BaseTransaction {
 		const sender = store.account.get(this.senderId);
 		const strippedSender = {
 			...sender,
-			secondPublicKey: undefined,
+			// tslint:disable-next-line no-null-keyword - Exception for compatibility with Core 1.4
+			secondPublicKey: null,
 			secondSignature: 0,
 		};
 

--- a/packages/lisk-transactions/src/transaction_types.ts
+++ b/packages/lisk-transactions/src/transaction_types.ts
@@ -20,6 +20,7 @@ export interface Account {
 	readonly delegate?: Delegate;
 	readonly publicKey?: string;
 	readonly secondPublicKey?: string;
+	readonly secondSignature?: boolean;
 	readonly membersPublicKeys?: ReadonlyArray<string>;
 	readonly multiMin?: number;
 	readonly multiLifetime?: number;

--- a/packages/lisk-transactions/src/transaction_types.ts
+++ b/packages/lisk-transactions/src/transaction_types.ts
@@ -19,7 +19,7 @@ export interface Account {
 	readonly balance: string;
 	readonly delegate?: Delegate;
 	readonly publicKey?: string;
-	readonly secondPublicKey?: string;
+	readonly secondPublicKey?: string | null;
 	readonly secondSignature?: number;
 	readonly membersPublicKeys?: ReadonlyArray<string>;
 	readonly multiMin?: number;

--- a/packages/lisk-transactions/src/transaction_types.ts
+++ b/packages/lisk-transactions/src/transaction_types.ts
@@ -20,7 +20,7 @@ export interface Account {
 	readonly delegate?: Delegate;
 	readonly publicKey?: string;
 	readonly secondPublicKey?: string;
-	readonly secondSignature?: boolean;
+	readonly secondSignature?: number;
 	readonly membersPublicKeys?: ReadonlyArray<string>;
 	readonly multiMin?: number;
 	readonly multiLifetime?: number;

--- a/packages/lisk-transactions/test/1_second_passphrase_transaction.ts
+++ b/packages/lisk-transactions/test/1_second_passphrase_transaction.ts
@@ -35,7 +35,7 @@ describe('Second signature registration transaction class', () => {
 		publicKey:
 			'8aceda0f39b35d778f55593227f97152f0b5a78b80b5c4ae88979909095d6204',
 		secondPublicKey: undefined,
-		secondSignature: false,
+		secondSignature: 0,
 	};
 
 	beforeEach(async () => {
@@ -181,7 +181,7 @@ describe('Second signature registration transaction class', () => {
 			expect(storeAccountSetStub).to.be.calledWithExactly(sender.address, {
 				...sender,
 				secondPublicKey: validTestTransaction.asset.signature.publicKey,
-				secondSignature: true,
+				secondSignature: 1,
 			});
 		});
 
@@ -211,7 +211,7 @@ describe('Second signature registration transaction class', () => {
 
 			expect(storeAccountSetStub).to.be.calledWithExactly(sender.address, {
 				...sender,
-				secondSignature: false,
+				secondSignature: 0,
 				secondPublicKey: undefined,
 			});
 		});

--- a/packages/lisk-transactions/test/1_second_passphrase_transaction.ts
+++ b/packages/lisk-transactions/test/1_second_passphrase_transaction.ts
@@ -34,6 +34,7 @@ describe('Second signature registration transaction class', () => {
 		balance: '32981247530771',
 		publicKey:
 			'8aceda0f39b35d778f55593227f97152f0b5a78b80b5c4ae88979909095d6204',
+		secondSignature: false,
 	};
 
 	beforeEach(async () => {
@@ -179,6 +180,7 @@ describe('Second signature registration transaction class', () => {
 			expect(storeAccountSetStub).to.be.calledWithExactly(sender.address, {
 				...sender,
 				secondPublicKey: validTestTransaction.asset.signature.publicKey,
+				secondSignature: true,
 			});
 		});
 
@@ -201,14 +203,14 @@ describe('Second signature registration transaction class', () => {
 
 	describe('#undoAsset', () => {
 		it('should call state store', async () => {
-			(validTestTransaction as any).applyAsset(store);
+			(validTestTransaction as any).undoAsset(store);
 			expect(storeAccountGetStub).to.be.calledWithExactly(
 				validTestTransaction.senderId,
 			);
-			expect(storeAccountSetStub).to.be.calledWithExactly(sender.address, {
-				...sender,
-				secondPublicKey: validTestTransaction.asset.signature.publicKey,
-			});
+			(sender.secondSignature = false),
+				expect(storeAccountSetStub).to.be.calledWithExactly(sender.address, {
+					...sender,
+				});
 		});
 
 		it('should return no errors', async () => {

--- a/packages/lisk-transactions/test/1_second_passphrase_transaction.ts
+++ b/packages/lisk-transactions/test/1_second_passphrase_transaction.ts
@@ -34,6 +34,7 @@ describe('Second signature registration transaction class', () => {
 		balance: '32981247530771',
 		publicKey:
 			'8aceda0f39b35d778f55593227f97152f0b5a78b80b5c4ae88979909095d6204',
+		secondPublicKey: undefined,
 		secondSignature: false,
 	};
 
@@ -207,10 +208,12 @@ describe('Second signature registration transaction class', () => {
 			expect(storeAccountGetStub).to.be.calledWithExactly(
 				validTestTransaction.senderId,
 			);
-			(sender.secondSignature = false),
-				expect(storeAccountSetStub).to.be.calledWithExactly(sender.address, {
-					...sender,
-				});
+
+			expect(storeAccountSetStub).to.be.calledWithExactly(sender.address, {
+				...sender,
+				secondSignature: false,
+				secondPublicKey: undefined,
+			});
 		});
 
 		it('should return no errors', async () => {

--- a/packages/lisk-transactions/test/1_second_passphrase_transaction.ts
+++ b/packages/lisk-transactions/test/1_second_passphrase_transaction.ts
@@ -34,7 +34,7 @@ describe('Second signature registration transaction class', () => {
 		balance: '32981247530771',
 		publicKey:
 			'8aceda0f39b35d778f55593227f97152f0b5a78b80b5c4ae88979909095d6204',
-		secondPublicKey: undefined,
+		secondPublicKey: null,
 		secondSignature: 0,
 	};
 
@@ -212,7 +212,7 @@ describe('Second signature registration transaction class', () => {
 			expect(storeAccountSetStub).to.be.calledWithExactly(sender.address, {
 				...sender,
 				secondSignature: 0,
-				secondPublicKey: undefined,
+				secondPublicKey: null,
 			});
 		});
 


### PR DESCRIPTION
### What was the problem?

- secondSignature flag was not being set

### How did I fix it?

- secondSignature flag is being added on apply asset and removed in undo

### How to test it?

Build should be green

### Review checklist

* The PR resolves #1147 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
