### PR TITLE
Fix receivedAt to use iso date format as input and store as date - Closes #1156

### DIFF
--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -57,12 +57,6 @@ export interface TransactionResponse {
 	readonly errors: ReadonlyArray<TransactionError>;
 }
 
-export interface Attributes {
-	readonly [entity: string]: {
-		readonly [property: string]: ReadonlyArray<string>;
-	};
-}
-
 export interface StateStoreGetter<T> {
 	get(key: string): T;
 	find(func: (item: T) => boolean): T | undefined;
@@ -162,7 +156,9 @@ export abstract class BaseTransaction {
 		this._signSignature = rawTransaction.signSignature;
 		this.timestamp = rawTransaction.timestamp;
 		this.type = rawTransaction.type;
-		this.receivedAt = rawTransaction.receivedAt || new Date();
+		this.receivedAt = rawTransaction.receivedAt
+			? new Date(rawTransaction.receivedAt)
+			: new Date();
 	}
 
 	public get id(): string {
@@ -200,7 +196,7 @@ export abstract class BaseTransaction {
 			signSignature: this.signSignature ? this.signSignature : undefined,
 			signatures: this.signatures,
 			asset: this.assetToJSON(),
-			receivedAt: this.receivedAt,
+			receivedAt: this.receivedAt.toISOString(),
 		};
 
 		return transaction;

--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -108,9 +108,9 @@ export abstract class BaseTransaction {
 	public readonly signatures: string[];
 	public readonly timestamp: number;
 	public readonly type: number;
-	public readonly receivedAt: Date;
 	public readonly containsUniqueData?: boolean;
 	public readonly fee: BigNum;
+	public receivedAt?: Date;
 
 	protected _id?: string;
 	protected _signature?: string;
@@ -158,7 +158,7 @@ export abstract class BaseTransaction {
 		this.type = rawTransaction.type;
 		this.receivedAt = rawTransaction.receivedAt
 			? new Date(rawTransaction.receivedAt)
-			: new Date();
+			: undefined;
 	}
 
 	public get id(): string {
@@ -196,7 +196,7 @@ export abstract class BaseTransaction {
 			signSignature: this.signSignature ? this.signSignature : undefined,
 			signatures: this.signatures,
 			asset: this.assetToJSON(),
-			receivedAt: this.receivedAt.toISOString(),
+			receivedAt: this.receivedAt ? this.receivedAt.toISOString() : undefined,
 		};
 
 		return transaction;
@@ -338,6 +338,9 @@ export abstract class BaseTransaction {
 	}
 
 	public isExpired(date: Date = new Date()): boolean {
+		if (!this.receivedAt) {
+			this.receivedAt = new Date();
+		}
 		// tslint:disable-next-line no-magic-numbers
 		const timeNow = Math.floor(date.getTime() / 1000);
 		const timeOut =

--- a/packages/lisk-transactions/src/transaction_types.ts
+++ b/packages/lisk-transactions/src/transaction_types.ts
@@ -47,7 +47,7 @@ export interface TransactionJSON {
 	readonly signSignature?: string;
 	readonly timestamp: number;
 	readonly type: number;
-	readonly receivedAt?: Date;
+	readonly receivedAt?: string;
 }
 
 export interface IsValidResponse {

--- a/packages/lisk-transactions/src/utils/validation/schema.ts
+++ b/packages/lisk-transactions/src/utils/validation/schema.ts
@@ -57,7 +57,7 @@ export const transaction = {
 			type: 'object',
 		},
 		receivedAt: {
-			type: 'object',
+			type: 'string',
 		},
 	},
 };
@@ -140,8 +140,8 @@ export const baseTransaction = {
 			type: 'object',
 		},
 		receivedAt: {
-			type: 'object',
-			format: 'receivedAt',
+			type: 'string',
+			format: 'date-time',
 		},
 	},
 };

--- a/packages/lisk-transactions/src/utils/validation/validator.ts
+++ b/packages/lisk-transactions/src/utils/validation/validator.ts
@@ -113,12 +113,6 @@ validator.addFormat('additionPublicKey', data => {
 	}
 });
 
-validator.addFormat(
-	'receivedAt',
-	(data: unknown) =>
-		data instanceof Date && !isNaN((data as unknown) as number),
-);
-
 validator.addFormat('username', validateUsername);
 
 validator.addFormat('noNullByte', data => !isNullByteIncluded(data));

--- a/packages/lisk-transactions/test/base_transaction.ts
+++ b/packages/lisk-transactions/test/base_transaction.ts
@@ -54,7 +54,6 @@ describe('Base transaction class', () => {
 	let storeAccountGetStub: sinon.SinonStub;
 	let storeAccountGetOrDefaultStub: sinon.SinonStub;
 
-
 	beforeEach(async () => {
 		validTestTransaction = new TestTransaction(defaultTransaction);
 		validSecondSignatureTestTransaction = new TestTransaction(
@@ -63,8 +62,12 @@ describe('Base transaction class', () => {
 		validMultisignatureTestTransaction = new TestTransaction(
 			defaultMultisignatureTransaction,
 		);
-		storeAccountGetStub = sandbox.stub(store.account, 'get').returns(defaultSenderAccount);
-		storeAccountGetOrDefaultStub = sandbox.stub(store.account, 'getOrDefault').returns(defaultSenderAccount);
+		storeAccountGetStub = sandbox
+			.stub(store.account, 'get')
+			.returns(defaultSenderAccount);
+		storeAccountGetOrDefaultStub = sandbox
+			.stub(store.account, 'getOrDefault')
+			.returns(defaultSenderAccount);
 	});
 
 	describe('#constructor', () => {
@@ -148,8 +151,8 @@ describe('Base transaction class', () => {
 
 		it('should have receivedAt Date', async () => {
 			expect(validTestTransaction)
-				.to.have.property('type')
-				.and.be.a('number');
+				.to.have.property('receivedAt')
+				.and.be.instanceOf(Date);
 		});
 
 		it('should have _multisignatureStatus number', async () => {
@@ -682,11 +685,11 @@ describe('Base transaction class', () => {
 		beforeEach(async () => {
 			const unexpiredTransaction = {
 				...defaultTransaction,
-				receivedAt: new Date(),
+				receivedAt: new Date().toISOString(),
 			};
 			const expiredTransaction = {
 				...defaultTransaction,
-				receivedAt: new Date(+new Date() - 1300 * 60000),
+				receivedAt: new Date(+new Date() - 1300 * 60000).toISOString(),
 			};
 			unexpiredTestTransaction = new TestTransaction(unexpiredTransaction);
 			expiredTestTransaction = new TestTransaction(expiredTransaction);

--- a/packages/lisk-transactions/test/create_signature_object.ts
+++ b/packages/lisk-transactions/test/create_signature_object.ts
@@ -35,7 +35,6 @@ describe('#createSignatureObject', () => {
 		signature:
 			'b84b95087c381ad25b5701096e2d9366ffd04037dcc941cd0747bfb0cf93111834a6c662f149018be4587e6fc4c9f5ba47aa5bbbd3dd836988f153aa8258e604',
 		id: '3694188453012384790',
-		receivedAt: new Date(),
 	};
 	const account = {
 		passphrase:

--- a/packages/lisk-transactions/test/helpers/add_transaction_fields.ts
+++ b/packages/lisk-transactions/test/helpers/add_transaction_fields.ts
@@ -18,7 +18,7 @@ export const addTransactionFields = (transaction: any) => {
 		signSignature: transaction.signSignature
 			? transaction.signSignature
 			: undefined,
-		receivedAt: new Date(),
+		receivedAt: new Date().toISOString(),
 		signatures: [...transaction.signatures],
 	};
 };

--- a/packages/lisk-transactions/test/utils/get_transaction_bytes.ts
+++ b/packages/lisk-transactions/test/utils/get_transaction_bytes.ts
@@ -72,7 +72,6 @@ describe('getTransactionBytes module', () => {
 					signature: defaultSignature,
 					signatures: [],
 					id: defaultTransactionId,
-					receivedAt: new Date(),
 				};
 				return Promise.resolve();
 			});
@@ -247,7 +246,6 @@ describe('getTransactionBytes module', () => {
 				signature: defaultSignature,
 				signatures: [],
 				id: defaultTransactionId,
-				receivedAt: new Date(),
 			};
 
 			it('should return Buffer of type 1 (register second signature) transaction', () => {
@@ -275,7 +273,6 @@ describe('getTransactionBytes module', () => {
 				signature: defaultSignature,
 				signatures: [],
 				id: defaultTransactionId,
-				receivedAt: new Date(),
 			};
 
 			it('should return Buffer of type 2 (register delegate) transaction', () => {
@@ -310,7 +307,6 @@ describe('getTransactionBytes module', () => {
 				signature: defaultSignature,
 				signatures: [],
 				id: defaultTransactionId,
-				receivedAt: new Date(),
 			};
 
 			it('should return Buffer of type 3 (vote) transaction', () => {
@@ -347,7 +343,6 @@ describe('getTransactionBytes module', () => {
 				signature: defaultSignature,
 				signatures: [],
 				id: defaultTransactionId,
-				receivedAt: new Date(),
 			};
 
 			it('should return Buffer from type 4 (register multisignature) transaction', () => {
@@ -388,7 +383,6 @@ describe('getTransactionBytes module', () => {
 				signature: defaultSignature,
 				signatures: [],
 				id: defaultTransactionId,
-				receivedAt: new Date(),
 			};
 
 			it('should return Buffer of type 5 (register dapp) transaction', () => {
@@ -416,7 +410,6 @@ describe('getTransactionBytes module', () => {
 				signature: defaultSignature,
 				signatures: [],
 				id: defaultTransactionId,
-				receivedAt: new Date(),
 			};
 
 			it('should return Buffer of type 6 (dapp inTransfer) transaction', () => {
@@ -449,7 +442,6 @@ describe('getTransactionBytes module', () => {
 				signature: defaultSignature,
 				signatures: [],
 				id: defaultTransactionId,
-				receivedAt: new Date(),
 			};
 
 			it('should return Buffer of type 7 (dapp outTransfer) transaction', () => {
@@ -796,7 +788,6 @@ describe('getTransactionBytes module', () => {
 					signature: defaultSignature,
 					signatures: [],
 					id: defaultTransactionId,
-					receivedAt: new Date(),
 				};
 				return Promise.resolve();
 			});

--- a/packages/lisk-transactions/test/utils/sign_and_validate.ts
+++ b/packages/lisk-transactions/test/utils/sign_and_validate.ts
@@ -279,7 +279,6 @@ describe('signAndVerify module', () => {
 				id: '13987348420913138422',
 				signatures: [],
 				senderPublicKey: defaultPublicKey,
-				receivedAt: new Date(),
 			};
 
 			cryptoSignDataStub = sandbox

--- a/packages/lisk-transactions/test/utils/sign_raw_transaction.ts
+++ b/packages/lisk-transactions/test/utils/sign_raw_transaction.ts
@@ -304,7 +304,6 @@ describe('#signRawTransaction', () => {
 				recipientPublicKey: '',
 				asset,
 				signatures: [],
-				receivedAt: new Date(),
 			};
 			return Promise.resolve();
 		});


### PR DESCRIPTION
### What was the problem?
property receivedAt did not have matching property input/output

### How did I fix it?
`receivedAt` takes in valid string format of date, and outputs ISODateFormat.
internally it stores Date object

### How to test it?
`npm t`

### Review checklist

* The PR resolves #1156
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
