### PR TITLE
Fix type 0 transaction to accept undefined asset - Closes #1157

### DIFF
--- a/packages/lisk-transactions/src/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/0_transfer_transaction.ts
@@ -61,7 +61,9 @@ export class TransferTransaction extends BaseTransaction {
 
 	public constructor(tx: TransactionJSON) {
 		super(tx);
-		const typeValid = validator.validate(transferAssetTypeSchema, tx.asset);
+		// Initializes to empty object if it doesn't exist
+		const asset = tx.asset || {};
+		const typeValid = validator.validate(transferAssetTypeSchema, asset);
 		const errors = validator.errors
 			? validator.errors.map(
 					error =>
@@ -76,7 +78,7 @@ export class TransferTransaction extends BaseTransaction {
 			throw new TransactionMultiError('Invalid asset types', tx.id, errors);
 		}
 
-		this.asset = tx.asset as TransferAsset;
+		this.asset = asset as TransferAsset;
 	}
 
 	protected assetToBytes(): Buffer {


### PR DESCRIPTION
### What was the problem?
Transfer transaction can have undefined asset field now, but it doesn't accept it

### How did I fix it?
if asset field does not exist in transfer transaction, it assigns empty object

### How to test it?
create transfer transaction with 
```
{
			"type": 0,
			"amount": "10008298357",
			"fee": 0,
			"timestamp": 0,
			"recipientId": "17033820735302139166L",
			"senderId": "6566229458323231555L",
			"senderPublicKey":
				"d121d3abf5425fdc0f161d9ddb32f89b7750b4bdb0bff7d18b191d4b4bafa6d4",
			"signature":
				"72c9b2aa734ec1b97549718ddf0d4737fd38a7f0fd105ea28486f2d989e9b3e399238d81a93aa45c27309d91ce604a5db9d25c9c90a138821f2011bc6636c60a",
			"id": "5449806225917864483"
}
```

### Review checklist

* The PR resolves #1157
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
