### PR TITLE
Change recipientId to accept null - Closes #1158

### DIFF
--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -151,7 +151,7 @@ export abstract class BaseTransaction {
 		this.amount = new BigNum(rawTransaction.amount);
 		this.fee = new BigNum(rawTransaction.fee);
 		this._id = rawTransaction.id;
-		this.recipientId = rawTransaction.recipientId;
+		this.recipientId = rawTransaction.recipientId || '';
 		this.recipientPublicKey = rawTransaction.recipientPublicKey || '';
 		this.senderId =
 			rawTransaction.senderId ||

--- a/packages/lisk-transactions/src/transaction_types.ts
+++ b/packages/lisk-transactions/src/transaction_types.ts
@@ -38,7 +38,7 @@ export interface TransactionJSON {
 	readonly asset: object;
 	readonly fee: string | number;
 	readonly id?: string;
-	readonly recipientId: string;
+	readonly recipientId: string | null;
 	readonly recipientPublicKey?: string;
 	readonly senderId?: string;
 	readonly senderPublicKey: string;

--- a/packages/lisk-transactions/src/utils/validation/schema.ts
+++ b/packages/lisk-transactions/src/utils/validation/schema.ts
@@ -39,7 +39,7 @@ export const transaction = {
 			type: 'string',
 		},
 		recipientId: {
-			type: 'string',
+			type: ['string', 'null'],
 		},
 		recipientPublicKey: {
 			type: ['string', 'null'],


### PR DESCRIPTION
### What was the problem?
Constructor did not accept recipientId as null, but genesis block contains vote transaction with null recipientId

### How did I fix it?
accept `null` as input of recipientId, and converted to empty string internally.
It will be validated at `validate` function.

### How to test it?
Create VoteTransaction with null recipientId

### Review checklist

* The PR resolves #1158 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
