### PR TITLE
When adding transaction, the transaction pool should return the name of the queue along with the status - Closes #1166

### DIFF
--- a/packages/lisk-transaction-pool/src/transaction_pool.ts
+++ b/packages/lisk-transaction-pool/src/transaction_pool.ts
@@ -67,6 +67,7 @@ export interface TransactionPoolConfiguration {
 export interface AddTransactionResult {
 	readonly alreadyExists: boolean;
 	readonly isFull: boolean;
+	readonly queueName: QueueNames;
 }
 
 interface TransactionPoolDependencies {
@@ -426,6 +427,7 @@ export class TransactionPool extends EventEmitter {
 			return {
 				isFull: false,
 				alreadyExists: true,
+				queueName,
 			};
 		}
 
@@ -433,6 +435,7 @@ export class TransactionPool extends EventEmitter {
 			return {
 				isFull: true,
 				alreadyExists: false,
+				queueName,
 			};
 		}
 		// Add receivedAt property for the transaction
@@ -449,6 +452,7 @@ export class TransactionPool extends EventEmitter {
 		return {
 			isFull: false,
 			alreadyExists: false,
+			queueName,
 		};
 	}
 


### PR DESCRIPTION
### What was the problem?
When adding transaction, the transaction pool did not return the name of the queue the transaction was being added to.

### How did I fix it?
Added the queue name with the function response.

### How to test it?
Run tests.
### Review checklist
* The PR resolves #1166 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
