### PR TITLE
Fix bug with processing multisignature transaction from a second signature enabled account - Closes #1163

### DIFF
--- a/packages/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/src/4_multisignature_transaction.ts
@@ -12,7 +12,6 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { hexToBuffer } from '@liskhq/lisk-cryptography';
 import * as BigNum from 'browserify-bignum';
 import {
 	BaseTransaction,
@@ -243,9 +242,7 @@ export class MultisignatureTransaction extends BaseTransaction {
 	}
 
 	public processMultisignatures(_: StateStore): TransactionResponse {
-		const transactionBytes = this.signSignature
-			? Buffer.concat([this.getBasicBytes(), hexToBuffer(this.signature)])
-			: this.getBasicBytes();
+		const transactionBytes = this.getBasicBytes();
 
 		const { valid, errors } = validateMultisignatures(
 			this.asset.multisignature.keysgroup.map(signedPublicKey =>

--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -321,9 +321,7 @@ export abstract class BaseTransaction {
 
 	public processMultisignatures(store: StateStore): TransactionResponse {
 		const sender = store.account.get(this.senderId);
-		const transactionBytes = this.signSignature
-			? Buffer.concat([this.getBasicBytes(), hexToBuffer(this.signature)])
-			: this.getBasicBytes();
+		const transactionBytes = this.getBasicBytes();
 
 		const { status, errors } = verifyMultiSignatures(
 			this.id,

--- a/packages/lisk-transactions/src/utils/sign_and_validate.ts
+++ b/packages/lisk-transactions/src/utils/sign_and_validate.ts
@@ -125,7 +125,7 @@ export const validateMultisignatures = (
 							new TransactionError(
 								`Failed to validate signature ${signature}`,
 								id,
-								'.signature',
+								'.signatures',
 							),
 				  )
 				: [],


### PR DESCRIPTION
### What was the problem?
The signatures from a second signature enabled account for multisignature transaction where not processed correctly.
### How did I fix it?
Removed including signature as a part of the transaction bytes during the processing of multi signatures.
### Review checklist

* The PR resolves #1163 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
