### PR TITLE
Add connectAndFetchPeers and new Discovery function Closes#1152

### DIFF
--- a/packages/lisk-p2p/src/errors.ts
+++ b/packages/lisk-p2p/src/errors.ts
@@ -58,6 +58,13 @@ export class RPCResponseError extends VError {
 	}
 }
 
+export class FetchPeerStatusError extends VError {
+	public constructor(message: string, cause: Error) {
+		super(cause, message);
+		this.name = 'FetchPeerStatusError';
+	}
+}
+
 export class InvalidRPCResponseError extends VError {
 	public constructor(message: string) {
 		super(message);

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -347,8 +347,13 @@ export class P2P extends EventEmitter {
 
 				const wsPort: number = parseInt(queryObject.wsPort, BASE_10_RADIX);
 				const peerId = constructPeerId(socket.remoteAddress, wsPort);
+				const queryOptions =
+					typeof queryObject.options === 'string'
+						? JSON.parse(queryObject.options)
+						: undefined;
 
 				const incomingPeerInfo: P2PDiscoveredPeerInfo = {
+					...queryOptions,
 					...queryObject,
 					ipAddress: socket.remoteAddress,
 					wsPort,
@@ -372,6 +377,7 @@ export class P2P extends EventEmitter {
 				}
 			},
 		);
+
 		this._httpServer.listen(this._nodeInfo.wsPort, NODE_HOST_IP);
 		if (this._scServer.isReady) {
 			this._isActive = true;

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -22,7 +22,11 @@ interface SCServerUpdated extends SCServer {
 	readonly isReady: boolean;
 }
 
-import { constructPeerId, constructPeerIdFromPeerInfo } from './peer';
+import {
+	connectAndFetchStatus,
+	constructPeerId,
+	constructPeerIdFromPeerInfo,
+} from './peer';
 
 import {
 	INCOMPATIBLE_NETWORK_CODE,
@@ -180,6 +184,9 @@ export class P2P extends EventEmitter {
 		this._handleDiscoveredPeer = (detailedPeerInfo: P2PDiscoveredPeerInfo) => {
 			const peerId = constructPeerIdFromPeerInfo(detailedPeerInfo);
 			if (!this._triedPeers.has(peerId)) {
+				if (this._newPeers.has(peerId)) {
+					this._newPeers.delete(peerId);
+				}
 				this._triedPeers.set(peerId, detailedPeerInfo);
 			}
 			// Re-emit the message to allow it to bubble up the class hierarchy.
@@ -344,17 +351,13 @@ export class P2P extends EventEmitter {
 
 				const wsPort: number = parseInt(queryObject.wsPort, BASE_10_RADIX);
 				const peerId = constructPeerId(socket.remoteAddress, wsPort);
-				const queryOptions =
-					typeof queryObject.options === 'string'
-						? JSON.parse(queryObject.options)
-						: undefined;
 
 				const incomingPeerInfo: P2PDiscoveredPeerInfo = {
+					...queryObject,
 					ipAddress: socket.remoteAddress,
 					wsPort,
 					height: queryObject.height ? +queryObject.height : 0,
 					version: queryObject.version,
-					...queryOptions,
 				};
 
 				const isNewPeer = this._peerPool.addInboundPeer(
@@ -366,9 +369,10 @@ export class P2P extends EventEmitter {
 				if (isNewPeer) {
 					this.emit(EVENT_NEW_INBOUND_PEER, incomingPeerInfo);
 					this.emit(EVENT_NEW_PEER, incomingPeerInfo);
-					if (!this._newPeers.has(peerId)) {
-						this._newPeers.set(peerId, incomingPeerInfo);
-					}
+				}
+
+				if (!this._newPeers.has(peerId) && !this._triedPeers.has(peerId)) {
+					this._newPeers.set(peerId, incomingPeerInfo);
 				}
 			},
 		);
@@ -412,18 +416,15 @@ export class P2P extends EventEmitter {
 	private async _discoverPeers(
 		knownPeers: ReadonlyArray<P2PDiscoveredPeerInfo> = [],
 	): Promise<void> {
-		const allKnownPeers: ReadonlyArray<
-			P2PDiscoveredPeerInfo
-		> = knownPeers.concat([...this._triedPeers.values()]);
-
 		// Make sure that we do not try to connect to peers if the P2P node is no longer active.
 		if (!this._isActive) {
 			return;
 		}
 
 		const discoveredPeers = await this._peerPool.runDiscovery(
-			allKnownPeers,
+			knownPeers,
 			this._config.blacklistedPeers,
+			this._nodeInfo,
 		);
 
 		// Stop discovery if node is no longer active. That way we don't try to connect to peers.
@@ -462,15 +463,40 @@ export class P2P extends EventEmitter {
 		clearInterval(this._discoveryIntervalId);
 	}
 
+	private async _fetchSeedPeerStatus(
+		seedPeers: ReadonlyArray<P2PPeerInfo>,
+	): Promise<ReadonlyArray<P2PDiscoveredPeerInfo>> {
+		const peerConfig = {
+			ackTimeout: this._config.ackTimeout,
+			connectTimeout: this._config.connectTimeout,
+		};
+		const seedPeerUpdatedInfos = await Promise.all(
+			seedPeers.map(async seedPeer =>
+				connectAndFetchStatus(seedPeer, this._nodeInfo, peerConfig),
+			),
+		);
+
+		return seedPeerUpdatedInfos;
+	}
+
 	public async start(): Promise<void> {
 		if (this._isActive) {
 			throw new Error('Cannot start the node because it is already active');
 		}
 		await this._startPeerServer();
+		// Fetch status of all the seed peers and then start the discovery
+		const seedPeerInfos = await this._fetchSeedPeerStatus(
+			this._config.seedPeers,
+		);
+		// Add seed's peerinfos in tried peer as we already tried them to fetch status
+		seedPeerInfos.forEach(seedInfo => {
+			const peerId = constructPeerIdFromPeerInfo(seedInfo);
+			if (!this._triedPeers.has(peerId)) {
+				this._triedPeers.set(peerId, seedInfo);
+			}
+		});
 		// TODO: Once we will a new peer discovery then we can remove this typecasting to P2PDiscoveredPeerInfo
-		await this._startDiscovery(this._config.seedPeers as ReadonlyArray<
-			P2PDiscoveredPeerInfo
-		>);
+		await this._startDiscovery(seedPeerInfos);
 	}
 
 	public async stop(): Promise<void> {

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -424,7 +424,6 @@ export class P2P extends EventEmitter {
 		const discoveredPeers = await this._peerPool.runDiscovery(
 			knownPeers,
 			this._config.blacklistedPeers,
-			this._nodeInfo,
 		);
 
 		// Stop discovery if node is no longer active. That way we don't try to connect to peers.

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -496,7 +496,7 @@ export class P2P extends EventEmitter {
 				this._triedPeers.set(peerId, seedInfo);
 			}
 		});
-		// TODO: Once we will a new peer discovery then we can remove this typecasting to P2PDiscoveredPeerInfo
+
 		await this._startDiscovery(seedPeerInfos);
 	}
 

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -22,11 +22,7 @@ interface SCServerUpdated extends SCServer {
 	readonly isReady: boolean;
 }
 
-import {
-	connectAndFetchStatus,
-	constructPeerId,
-	constructPeerIdFromPeerInfo,
-} from './peer';
+import { constructPeerId, constructPeerIdFromPeerInfo } from './peer';
 
 import {
 	INCOMPATIBLE_NETWORK_CODE,
@@ -469,10 +465,10 @@ export class P2P extends EventEmitter {
 			ackTimeout: this._config.ackTimeout,
 			connectTimeout: this._config.connectTimeout,
 		};
-		const seedPeerUpdatedInfos = await Promise.all(
-			seedPeers.map(async seedPeer =>
-				connectAndFetchStatus(seedPeer, this._nodeInfo, peerConfig),
-			),
+		const seedPeerUpdatedInfos = await this._peerPool.fetchStatusAndCreatePeer(
+			seedPeers,
+			this._nodeInfo,
+			peerConfig,
 		);
 
 		return seedPeerUpdatedInfos;

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -471,7 +471,7 @@ export class P2P extends EventEmitter {
 			ackTimeout: this._config.ackTimeout,
 			connectTimeout: this._config.connectTimeout,
 		};
-		const seedPeerUpdatedInfos = await this._peerPool.fetchStatusAndCreatePeer(
+		const seedPeerUpdatedInfos = await this._peerPool.fetchStatusAndCreatePeers(
 			seedPeers,
 			this._nodeInfo,
 			peerConfig,

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -694,7 +694,7 @@ export const connectAndFetchPeerInfo = async (
 	basicPeerInfo: P2PPeerInfo,
 	nodeInfo?: P2PNodeInfo,
 	peerConfig?: PeerConfig,
-): Promise<PeerInfoAndOutboundConnection | Error> => {
+): Promise<PeerInfoAndOutboundConnection> => {
 	try {
 		const { responsePacket, socket } = await connectAndRequest(
 			basicPeerInfo,
@@ -713,6 +713,6 @@ export const connectAndFetchPeerInfo = async (
 
 		return { peerInfo, socket };
 	} catch (error) {
-		return error;
+		throw error;
 	}
 };

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -664,11 +664,11 @@ export const connectAndRequest = async (
 		},
 	);
 
-export const connectAndFetchStatus = async (
+export const connectAndFetchPeerInfo = async (
 	basicPeerInfo: P2PPeerInfo,
 	nodeInfo?: P2PNodeInfo,
 	peerConfig?: PeerConfig,
-): Promise<PeerInfoAndOutboundConnection> => {
+): Promise<PeerInfoAndOutboundConnection | Error> => {
 	try {
 		const { responsePacket, socket } = await connectAndRequest(
 			basicPeerInfo,
@@ -687,6 +687,6 @@ export const connectAndFetchStatus = async (
 
 		return { peerInfo, socket };
 	} catch (error) {
-		throw error;
+		return error;
 	}
 };

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -15,7 +15,7 @@
 
 import { EventEmitter } from 'events';
 import * as querystring from 'querystring';
-import { RPCResponseError } from './errors';
+import { FetchPeerStatusError, RPCResponseError } from './errors';
 
 import {
 	P2PDiscoveredPeerInfo,
@@ -713,6 +713,11 @@ export const connectAndFetchPeerInfo = async (
 
 		return { peerInfo, socket };
 	} catch (error) {
-		throw error;
+		throw new FetchPeerStatusError(
+			`Error occurred while fetching information from ${
+				basicPeerInfo.ipAddress
+			}:${basicPeerInfo.wsPort}`,
+			error,
+		);
 	}
 };

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -572,3 +572,139 @@ export class Peer extends EventEmitter {
 		request.end(legacyNodeInfo);
 	}
 }
+
+export interface ConnectAndFetchResponse {
+	readonly responsePacket: P2PResponsePacket;
+	readonly socket?: SCClientSocket;
+}
+
+export const connectAndRequest = async (
+	basicPeerInfo: P2PPeerInfo,
+	procedure: string,
+	nodeInfo?: P2PNodeInfo,
+	peerConfig?: PeerConfig,
+): Promise<ConnectAndFetchResponse> =>
+	new Promise<ConnectAndFetchResponse>(
+		(
+			resolve: (result: ConnectAndFetchResponse) => void,
+			reject: (result: Error) => void,
+		): void => {
+			const legacyNodeInfo = nodeInfo
+				? convertNodeInfoToLegacyFormat(nodeInfo)
+				: undefined;
+
+			const requestPacket = {
+				procedure,
+			};
+			const clientOptions: ClientOptionsUpdated = {
+				hostname: basicPeerInfo.ipAddress,
+				port: basicPeerInfo.wsPort,
+				query: querystring.stringify(legacyNodeInfo),
+				connectTimeout: peerConfig
+					? peerConfig.connectTimeout
+						? peerConfig.connectTimeout
+						: DEFAULT_CONNECT_TIMEOUT
+					: DEFAULT_CONNECT_TIMEOUT,
+				ackTimeout: peerConfig
+					? peerConfig.connectTimeout
+						? peerConfig.connectTimeout
+						: DEFAULT_CONNECT_TIMEOUT
+					: DEFAULT_ACK_TIMEOUT,
+				multiplex: false,
+				autoConnect: false,
+				autoReconnect: false,
+				pingTimeoutDisabled: true,
+			};
+
+			const outboundSocket = socketClusterClient.create(clientOptions);
+
+			outboundSocket.emit(
+				REMOTE_EVENT_RPC_REQUEST,
+				{
+					type: '/RPCRequest',
+					procedure: requestPacket.procedure,
+				},
+				(err: Error | undefined, responseData: unknown) => {
+					if (err) {
+						reject(err);
+
+						return;
+					}
+					if (responseData) {
+						const responsePacket = responseData as P2PResponsePacket;
+
+						resolve({
+							responsePacket,
+							socket: outboundSocket,
+						});
+
+						return;
+					}
+
+					reject(
+						new RPCResponseError(
+							`Failed to handle response for procedure ${
+								requestPacket.procedure
+							}`,
+							new Error('RPC response format was invalid'),
+							basicPeerInfo.ipAddress,
+							basicPeerInfo.wsPort,
+						),
+					);
+				},
+			);
+		},
+	);
+
+export const connectAndFetchPeers = async (
+	basicPeerInfo: P2PPeerInfo,
+	nodeInfo?: P2PNodeInfo,
+	peerConfig?: PeerConfig,
+): Promise<ReadonlyArray<P2PDiscoveredPeerInfo>> => {
+	const { responsePacket, socket } = await connectAndRequest(
+		basicPeerInfo,
+		REMOTE_RPC_GET_ALL_PEERS_LIST,
+		nodeInfo,
+		peerConfig,
+	);
+	if (socket) {
+		socket.destroy();
+	}
+
+	try {
+		const peers = validatePeerInfoList(responsePacket.data);
+
+		return peers;
+	} catch (error) {
+		throw error;
+	}
+};
+
+export const connectAndFetchStatus = async (
+	basicPeerInfo: P2PPeerInfo,
+	nodeInfo?: P2PNodeInfo,
+	peerConfig?: PeerConfig,
+): Promise<P2PDiscoveredPeerInfo> => {
+	const { responsePacket, socket } = await connectAndRequest(
+		basicPeerInfo,
+		REMOTE_RPC_GET_NODE_INFO,
+		nodeInfo,
+		peerConfig,
+	);
+	if (socket) {
+		socket.destroy();
+	}
+	const protocolPeerInfo = responsePacket.data;
+	const rawPeerInfo = {
+		...protocolPeerInfo,
+		ip: basicPeerInfo.ipAddress,
+		wsPort: basicPeerInfo.wsPort,
+	};
+	try {
+		const peerInfo = validatePeerInfo(rawPeerInfo);
+
+		return peerInfo;
+	} catch (error) {
+		throw error;
+	}
+};

--- a/packages/lisk-p2p/src/peer.ts
+++ b/packages/lisk-p2p/src/peer.ts
@@ -103,12 +103,31 @@ export const constructPeerIdFromPeerInfo = (peerInfo: P2PPeerInfo): string =>
 // Format the node info so that it will be valid from the perspective of both new and legacy nodes.
 const convertNodeInfoToLegacyFormat = (
 	nodeInfo: P2PNodeInfo,
-): ProtocolNodeInfo => ({
-	...nodeInfo,
-	httpPort: nodeInfo ? (nodeInfo.httpPort as number) : 0,
-	broadhash: nodeInfo ? (nodeInfo.broadhash as string) : '',
-	nonce: nodeInfo ? (nodeInfo.nonce as string) : '',
-});
+): ProtocolNodeInfo => {
+	const {
+		height,
+		nethash,
+		version,
+		os,
+		wsPort,
+		httpPort,
+		nonce,
+		broadhash,
+		...options
+	} = nodeInfo;
+
+	return {
+		height,
+		nethash,
+		version,
+		os,
+		wsPort,
+		broadhash: broadhash ? (broadhash as string) : '',
+		httpPort: httpPort ? (httpPort as number) : 0,
+		nonce: nonce ? (nonce as string) : '',
+		options,
+	};
+};
 
 export interface PeerConfig {
 	readonly connectTimeout?: number;
@@ -608,7 +627,13 @@ export const connectAndRequest = async (
 			const clientOptions: ClientOptionsUpdated = {
 				hostname: basicPeerInfo.ipAddress,
 				port: basicPeerInfo.wsPort,
-				query: querystring.stringify(legacyNodeInfo),
+				query: querystring.stringify({
+					...legacyNodeInfo,
+					options:
+						legacyNodeInfo && legacyNodeInfo.options
+							? JSON.stringify(legacyNodeInfo.options)
+							: undefined,
+				}),
 				connectTimeout: peerConfig
 					? peerConfig.connectTimeout
 						? peerConfig.connectTimeout

--- a/packages/lisk-p2p/src/peer_discovery.ts
+++ b/packages/lisk-p2p/src/peer_discovery.ts
@@ -12,12 +12,8 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { P2PDiscoveredPeerInfo, P2PNodeInfo, P2PPeerInfo } from './p2p_types';
-import {
-	connectAndFetchPeers,
-	constructPeerIdFromPeerInfo,
-	PeerConfig,
-} from './peer';
+import { P2PDiscoveredPeerInfo } from './p2p_types';
+import { constructPeerIdFromPeerInfo, Peer } from './peer';
 // For Lips, this will be used for fixed and white lists
 export interface FilterPeerOptions {
 	readonly blacklist: ReadonlyArray<string>;
@@ -25,17 +21,15 @@ export interface FilterPeerOptions {
 
 // TODO later: Implement LIPS to handle fixed and white list
 export const discoverPeers = async (
-	knownPeers: ReadonlyArray<P2PPeerInfo>,
+	knownPeers: ReadonlyArray<Peer>,
 	filterPeerOptions: FilterPeerOptions = { blacklist: [] },
-	nodeInfo?: P2PNodeInfo,
-	peerConfig?: PeerConfig,
 ): Promise<ReadonlyArray<P2PDiscoveredPeerInfo>> => {
 	const peersOfPeer: ReadonlyArray<
 		ReadonlyArray<P2PDiscoveredPeerInfo>
 	> = await Promise.all(
 		knownPeers.map(async peer => {
 			try {
-				return await connectAndFetchPeers(peer, nodeInfo, peerConfig);
+				return await peer.fetchPeers();
 			} catch (error) {
 				return [];
 			}

--- a/packages/lisk-p2p/src/peer_discovery.ts
+++ b/packages/lisk-p2p/src/peer_discovery.ts
@@ -12,23 +12,30 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
-import { P2PDiscoveredPeerInfo } from './p2p_types';
-import { constructPeerIdFromPeerInfo, Peer } from './peer';
+import { P2PDiscoveredPeerInfo, P2PNodeInfo, P2PPeerInfo } from './p2p_types';
+import {
+	connectAndFetchPeers,
+	constructPeerIdFromPeerInfo,
+	PeerConfig,
+} from './peer';
 // For Lips, this will be used for fixed and white lists
 export interface FilterPeerOptions {
 	readonly blacklist: ReadonlyArray<string>;
 }
+
 // TODO later: Implement LIPS to handle fixed and white list
 export const discoverPeers = async (
-	knownPeers: ReadonlyArray<Peer>,
+	knownPeers: ReadonlyArray<P2PPeerInfo>,
 	filterPeerOptions: FilterPeerOptions = { blacklist: [] },
+	nodeInfo?: P2PNodeInfo,
+	peerConfig?: PeerConfig,
 ): Promise<ReadonlyArray<P2PDiscoveredPeerInfo>> => {
 	const peersOfPeer: ReadonlyArray<
 		ReadonlyArray<P2PDiscoveredPeerInfo>
 	> = await Promise.all(
 		knownPeers.map(async peer => {
 			try {
-				return await peer.fetchPeers();
+				return await connectAndFetchPeers(peer, nodeInfo, peerConfig);
 			} catch (error) {
 				return [];
 			}

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -256,7 +256,7 @@ export class PeerPool extends EventEmitter {
 		});
 	}
 
-	public async fetchStatusAndCreatePeer(
+	public async fetchStatusAndCreatePeers(
 		seedPeers: ReadonlyArray<P2PPeerInfo>,
 		nodeInfo: P2PNodeInfo,
 		peerConfig: PeerConfig,

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -280,7 +280,9 @@ export class PeerPool extends EventEmitter {
 					);
 
 					return seedFetchStatusResponse.peerInfo;
-				} catch (err) {
+				} catch (error) {
+					this.emit(EVENT_FAILED_TO_FETCH_PEER_INFO, error);
+
 					return undefined;
 				}
 			}),

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -354,7 +354,7 @@ export class PeerPool extends EventEmitter {
 			connectTimeout: this._peerPoolConfig.connectTimeout,
 			ackTimeout: this._peerPoolConfig.ackTimeout,
 		};
-		const peer = new Peer(peerInfo, peerConfig, inboundSocket);
+		const peer = new Peer(peerInfo, peerConfig, { inbound: inboundSocket });
 
 		// Throw an error because adding a peer multiple times is a common developer error which is very difficult to itentify and debug.
 		if (this._peerMap.has(peer.id)) {
@@ -378,7 +378,9 @@ export class PeerPool extends EventEmitter {
 			connectTimeout: this._peerPoolConfig.connectTimeout,
 			ackTimeout: this._peerPoolConfig.ackTimeout,
 		};
-		const peer = new Peer(detailedPeerInfo, peerConfig, inboundSocket);
+		const peer = new Peer(detailedPeerInfo, peerConfig, {
+			inbound: inboundSocket,
+		});
 		this._peerMap.set(peer.id, peer);
 		this._bindHandlersToPeer(peer);
 		if (this._nodeInfo) {
@@ -437,8 +439,7 @@ export class PeerPool extends EventEmitter {
 			connectTimeout: this._peerPoolConfig.connectTimeout,
 			ackTimeout: this._peerPoolConfig.ackTimeout,
 		};
-		const peer = new Peer(peerInfo, peerConfig);
-		peer.createPeerFromOutboundConnection(socket);
+		const peer = new Peer(peerInfo, peerConfig, { outbound: socket });
 
 		// Throw an error because adding a peer multiple times is a common developer error which is very difficult to itentify and debug.
 		this._peerMap.set(peer.id, peer);

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -362,7 +362,7 @@ export class PeerPool extends EventEmitter {
 		};
 		const peer = new Peer(peerInfo, peerConfig, { inbound: inboundSocket });
 
-		// Throw an error because adding a peer multiple times is a common developer error which is very difficult to itentify and debug.
+		// Throw an error because adding a peer multiple times is a common developer error which is very difficult to identify and debug.
 		if (this._peerMap.has(peer.id)) {
 			throw new Error(`Peer ${peer.id} was already in the peer pool`);
 		}
@@ -447,7 +447,6 @@ export class PeerPool extends EventEmitter {
 		};
 		const peer = new Peer(peerInfo, peerConfig, { outbound: socket });
 
-		// Throw an error because adding a peer multiple times is a common developer error which is very difficult to itentify and debug.
 		this._peerMap.set(peer.id, peer);
 		this._bindHandlersToPeer(peer);
 		if (this._nodeInfo) {

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -269,7 +269,13 @@ export class PeerPool extends EventEmitter {
 
 			return this.addPeer(peerInfo);
 		});
-		const discoveredPeers = await discoverPeers(peersForDiscovery, {
+
+		const peerSampleToProbe = selectRandomPeerSample(
+			peersForDiscovery,
+			MAX_PEER_DISCOVERY_PROBE_SAMPLE_SIZE,
+		);
+
+		const discoveredPeers = await discoverPeers(peerSampleToProbe, {
 			blacklist: blacklist.map(peer => peer.ipAddress),
 		});
 

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -294,9 +294,8 @@ export class PeerPool extends EventEmitter {
 	): Promise<ReadonlyArray<P2PDiscoveredPeerInfo>> {
 		const peersForDiscovery = knownPeers.map(peerInfo => {
 			const peerId = constructPeerIdFromPeerInfo(peerInfo);
-			if (this.hasPeer(peerId)) {
-				const existingPeer = this.getPeer(peerId) as Peer;
-
+			const existingPeer = this.getPeer(peerId);
+			if (existingPeer) {
 				existingPeer.updatePeerInfo(peerInfo);
 
 				return existingPeer;
@@ -317,9 +316,9 @@ export class PeerPool extends EventEmitter {
 		// Check for received discovery info and then find it in peer pool and then update it
 		discoveredPeers.forEach((peerInfo: P2PDiscoveredPeerInfo) => {
 			const peerId = constructPeerIdFromPeerInfo(peerInfo);
-			if (this.hasPeer(peerId)) {
-				const existingPeer = this.getPeer(peerId) as Peer;
+			const existingPeer = this.getPeer(peerId);
 
+			if (existingPeer) {
 				existingPeer.updatePeerInfo(peerInfo);
 			}
 		});
@@ -334,10 +333,10 @@ export class PeerPool extends EventEmitter {
 
 		peersToConnect.forEach((peerInfo: P2PDiscoveredPeerInfo) => {
 			const peerId = constructPeerIdFromPeerInfo(peerInfo);
-			if (!this.hasPeer(peerId)) {
-				this.addPeer(peerInfo);
+			const existingPeer = this.getPeer(peerId);
+			if (!existingPeer) {
+				return this.addPeer(peerInfo);
 			}
-			const existingPeer = this.getPeer(peerId) as Peer;
 
 			existingPeer.updatePeerInfo(peerInfo);
 

--- a/packages/lisk-p2p/src/validation.ts
+++ b/packages/lisk-p2p/src/validation.ts
@@ -74,10 +74,12 @@ export const validatePeerInfo = (
 		protocolPeer.height && isNumeric(protocolPeer.height.toString())
 			? +protocolPeer.height
 			: 0;
+	const { options, ...protocolPeerWithoutOptions } = protocolPeer;
 
 	const peerInfo: P2PDiscoveredPeerInfo = {
-		...protocolPeer,
-		ipAddress: protocolPeer.ip,
+		...(options as object),
+		...protocolPeerWithoutOptions,
+		ipAddress: protocolPeerWithoutOptions.ip,
 		wsPort,
 		height,
 		os,

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -28,11 +28,9 @@ describe('Integration tests for P2P library', () => {
 						version: '1.0.0',
 						os: platform(),
 						height: 0,
-						options: {
-							broadhash:
-								'2768b267ae621a9ed3b3034e2e8a1bed40895c621bbb1bbd613d92b9d24e54b5',
-							nonce: 'O2wTkjqplHII5wPv',
-						},
+						broadhash:
+							'2768b267ae621a9ed3b3034e2e8a1bed40895c621bbb1bbd613d92b9d24e54b5',
+						nonce: 'O2wTkjqplHII5wPv',
 					},
 				});
 			});
@@ -99,11 +97,9 @@ describe('Integration tests for P2P library', () => {
 						version: '1.0.0',
 						os: platform(),
 						height: 0,
-						options: {
-							broadhash:
-								'2768b267ae621a9ed3b3034e2e8a1bed40895c621bbb1bbd613d92b9d24e54b5',
-							nonce: 'O2wTkjqplHII5wPv',
-						},
+						broadhash:
+							'2768b267ae621a9ed3b3034e2e8a1bed40895c621bbb1bbd613d92b9d24e54b5',
+						nonce: 'O2wTkjqplHII5wPv',
 					},
 				});
 			});
@@ -333,11 +329,9 @@ describe('Integration tests for P2P library', () => {
 						version: '1.0.0',
 						os: platform(),
 						height: 0,
-						options: {
-							broadhash:
-								'2768b267ae621a9ed3b3034e2e8a1bed40895c621bbb1bbd613d92b9d24e54b5',
-							nonce: 'O2wTkjqplHII5wPv',
-						},
+						broadhash:
+							'2768b267ae621a9ed3b3034e2e8a1bed40895c621bbb1bbd613d92b9d24e54b5',
+						nonce: 'O2wTkjqplHII5wPv',
 					},
 				});
 			});

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -341,12 +341,9 @@ describe('Integration tests for P2P library', () => {
 			});
 		});
 
-		describe.skip('When half of the nodes crash', () => {
+		describe('When half of the nodes crash', () => {
 			it('should get network status with all unresponsive nodes removed', async () => {
 				const firstP2PNode = p2pNodeList[0];
-				p2pNodeList.forEach(p2p =>
-					console.log(p2p.isActive, p2p.nodeInfo.wsPort),
-				);
 				// Stop all the nodes with port from 5001 to 5005
 				p2pNodeList.forEach(async (p2p: any, index: number) => {
 					if (index !== 0 && index < NETWORK_PEER_COUNT / 2) {
@@ -488,26 +485,30 @@ describe('Integration tests for P2P library', () => {
 			});
 		});
 
-		describe.skip('Cleanup unresponsive peers', () => {
+		describe('Cleanup unresponsive peers', () => {
 			it('should remove inactive 2nd node from connected peer list of other', async () => {
-				const initialNetworkStatus = p2pNodeList[2].getNetworkStatus();
+				const initialNetworkStatus = p2pNodeList[0].getNetworkStatus();
 				const secondNode = p2pNodeList[1];
 				const initialPeerPorts = initialNetworkStatus.connectedPeers
 					.map(peerInfo => peerInfo.wsPort)
 					.sort();
 
-				expect(initialPeerPorts).to.be.eql(ALL_NODE_PORTS);
+				const expectedPeerPorts = ALL_NODE_PORTS.filter(port => {
+					return port !== 5000;
+				});
+				expect(initialPeerPorts).to.be.eql(expectedPeerPorts);
 				await secondNode.stop();
-				await wait(100);
 
-				const networkStatusAfterPeerCrash = p2pNodeList[2].getNetworkStatus();
+				await wait(200);
+
+				const networkStatusAfterPeerCrash = p2pNodeList[0].getNetworkStatus();
 
 				const peerPortsAfterPeerCrash = networkStatusAfterPeerCrash.connectedPeers
 					.map(peerInfo => peerInfo.wsPort)
 					.sort();
 
 				const expectedPeerPortsAfterPeerCrash = ALL_NODE_PORTS.filter(port => {
-					return port !== 5001;
+					return port !== 5000 && port != 5001;
 				});
 
 				expect(peerPortsAfterPeerCrash).to.be.eql(
@@ -711,7 +712,7 @@ describe('Integration tests for P2P library', () => {
 			});
 		});
 
-		describe.skip('when couple of node shuts down and are unresponsive', () => {
+		describe('when couple of node shuts down and are unresponsive', () => {
 			it('should remove the unresponsive nodes from network status of other nodes', async () => {
 				const initialNetworkStatus = p2pNodeList[0].getNetworkStatus();
 				const initialPeerPorts = initialNetworkStatus.connectedPeers

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -416,8 +416,9 @@ describe('Integration tests for P2P library', () => {
 			// Launch nodes one at a time with a delay between each launch.
 			for (const p2p of p2pNodeList) {
 				await p2p.start();
+				await wait(100);
 			}
-			await wait(200);
+			await wait(100);
 		});
 
 		afterEach(async () => {

--- a/packages/lisk-p2p/test/unit/peer_discovery.ts
+++ b/packages/lisk-p2p/test/unit/peer_discovery.ts
@@ -16,8 +16,9 @@ import { expect } from 'chai';
 import { P2PDiscoveredPeerInfo } from '../../src/p2p_types';
 import { initializePeerList } from '../utils/peers';
 import * as discoverPeersModule from '../../src/peer_discovery';
+import * as PeersModule from '../../src/peer';
 
-describe.skip('peer discovery', () => {
+describe('peer discovery', () => {
 	const samplePeers = initializePeerList();
 	const seedPeer1 = samplePeers[0];
 	const seedPeer2 = samplePeers[1];
@@ -27,7 +28,6 @@ describe.skip('peer discovery', () => {
 		ipAddress: '196.34.89.90',
 		wsPort: 5393,
 		height: 23232,
-		isDiscoveredPeer: true,
 		version: '1.2.1',
 	};
 
@@ -35,7 +35,6 @@ describe.skip('peer discovery', () => {
 		ipAddress: '128.38.75.9',
 		wsPort: 5393,
 		height: 23232,
-		isDiscoveredPeer: true,
 		version: '1.2.1',
 	};
 
@@ -43,22 +42,18 @@ describe.skip('peer discovery', () => {
 		ipAddress: '12.23.11.31',
 		wsPort: 5393,
 		height: 23232,
-		isDiscoveredPeer: true,
 		version: '1.3.1',
 	};
 
 	describe('#discoverPeer', () => {
-		const peerList1 = [validatedPeer1, validatedPeer2];
-		const peerList2 = [validatedPeer1, validatedPeer3];
-
+		const peerList = [validatedPeer1, validatedPeer2, validatedPeer3];
 		const expectedResult = [validatedPeer1, validatedPeer2];
 
 		describe('return an array with all the peers of input peers', () => {
 			let discoveredPeers: ReadonlyArray<P2PDiscoveredPeerInfo>;
 			const blacklist = ['12.23.11.31'];
 			beforeEach(async () => {
-				sandbox.stub(seedPeer1, 'fetchPeers').resolves(peerList1);
-				sandbox.stub(seedPeer2, 'fetchPeers').resolves(peerList2);
+				sandbox.stub(PeersModule, 'connectAndFetchPeers').resolves(peerList);
 
 				discoveredPeers = await discoverPeersModule.discoverPeers(seedList, {
 					blacklist,

--- a/packages/lisk-p2p/test/unit/peer_discovery.ts
+++ b/packages/lisk-p2p/test/unit/peer_discovery.ts
@@ -16,7 +16,6 @@ import { expect } from 'chai';
 import { P2PDiscoveredPeerInfo } from '../../src/p2p_types';
 import { initializePeerList } from '../utils/peers';
 import * as discoverPeersModule from '../../src/peer_discovery';
-import * as PeersModule from '../../src/peer';
 
 describe('peer discovery', () => {
 	const samplePeers = initializePeerList();
@@ -28,6 +27,7 @@ describe('peer discovery', () => {
 		ipAddress: '196.34.89.90',
 		wsPort: 5393,
 		height: 23232,
+		isDiscoveredPeer: true,
 		version: '1.2.1',
 	};
 
@@ -35,6 +35,7 @@ describe('peer discovery', () => {
 		ipAddress: '128.38.75.9',
 		wsPort: 5393,
 		height: 23232,
+		isDiscoveredPeer: true,
 		version: '1.2.1',
 	};
 
@@ -42,18 +43,22 @@ describe('peer discovery', () => {
 		ipAddress: '12.23.11.31',
 		wsPort: 5393,
 		height: 23232,
+		isDiscoveredPeer: true,
 		version: '1.3.1',
 	};
 
 	describe('#discoverPeer', () => {
-		const peerList = [validatedPeer1, validatedPeer2, validatedPeer3];
+		const peerList1 = [validatedPeer1, validatedPeer2];
+		const peerList2 = [validatedPeer1, validatedPeer3];
+
 		const expectedResult = [validatedPeer1, validatedPeer2];
 
 		describe('return an array with all the peers of input peers', () => {
 			let discoveredPeers: ReadonlyArray<P2PDiscoveredPeerInfo>;
 			const blacklist = ['12.23.11.31'];
 			beforeEach(async () => {
-				sandbox.stub(PeersModule, 'connectAndFetchPeers').resolves(peerList);
+				sandbox.stub(seedPeer1, 'fetchPeers').resolves(peerList1);
+				sandbox.stub(seedPeer2, 'fetchPeers').resolves(peerList2);
 
 				discoveredPeers = await discoverPeersModule.discoverPeers(seedList, {
 					blacklist,

--- a/packages/lisk-p2p/test/unit/peer_discovery.ts
+++ b/packages/lisk-p2p/test/unit/peer_discovery.ts
@@ -17,7 +17,7 @@ import { P2PDiscoveredPeerInfo } from '../../src/p2p_types';
 import { initializePeerList } from '../utils/peers';
 import * as discoverPeersModule from '../../src/peer_discovery';
 
-describe('peer discovery', () => {
+describe.skip('peer discovery', () => {
 	const samplePeers = initializePeerList();
 	const seedPeer1 = samplePeers[0];
 	const seedPeer2 = samplePeers[1];


### PR DESCRIPTION
### Description

Discovery should just take `IP` address and `wPort` and should be able to connect and fetch peer list independently of `Peer` object. This will remove the need to create `Peer` objects for the seed peers just to fetch peer list from them. Also, it will be independent of the peer pool in terms of choosing peers with Peer objects already and could be handled independently.

- Add new `connectAndFetchPeers` method that will fetch all the peers from `P2PPeerInfo ({ipAddress, wsPort})`, this will assign an outbound socket and destroy it after fetching peers.

- Update discovery function `discoverPeer` to use `connectAndFetchPeers` to fetch peers from the peers passed as arguments.

- Update P2P `start()` method and subsequent `_startDiscovery()` methods to use and accept new updated discovery method.

### Review checklist

* The PR resolves #1152
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
