### PR TITLE
Add blockId to base transaction

### DIFF
--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -102,6 +102,7 @@ export const ENTITY_TRANSACTION = 'transaction';
 export abstract class BaseTransaction {
 	public readonly amount: BigNum;
 	public readonly recipientId: string;
+	public readonly blockId?: string;
 	public readonly recipientPublicKey?: string;
 	public readonly senderId: string;
 	public readonly senderPublicKey: string;
@@ -184,6 +185,7 @@ export abstract class BaseTransaction {
 	public toJSON(): TransactionJSON {
 		const transaction = {
 			id: this.id,
+			blockId: this.blockId,
 			amount: this.amount.toString(),
 			type: this.type,
 			timestamp: this.timestamp,

--- a/packages/lisk-transactions/src/transaction_types.ts
+++ b/packages/lisk-transactions/src/transaction_types.ts
@@ -38,6 +38,7 @@ export interface TransactionJSON {
 	readonly asset: object;
 	readonly fee: string | number;
 	readonly id?: string;
+	readonly blockId?: string;
 	readonly recipientId: string | null;
 	readonly recipientPublicKey?: string;
 	readonly senderId?: string;

--- a/packages/lisk-transactions/src/utils/validation/schema.ts
+++ b/packages/lisk-transactions/src/utils/validation/schema.ts
@@ -20,6 +20,9 @@ export const transaction = {
 		id: {
 			type: 'string',
 		},
+		blockId: {
+			type: 'string',
+		},
 		amount: {
 			type: ['string', 'integer'],
 		},
@@ -78,6 +81,10 @@ export const baseTransaction = {
 	],
 	properties: {
 		id: {
+			type: 'string',
+			format: 'id',
+		},
+		blockId: {
 			type: 'string',
 			format: 'id',
 		},

--- a/packages/lisk-transactions/test/helpers/add_transaction_fields.ts
+++ b/packages/lisk-transactions/test/helpers/add_transaction_fields.ts
@@ -15,6 +15,7 @@
 export const addTransactionFields = (transaction: any) => {
 	return {
 		...transaction,
+		blockId: undefined,
 		signSignature: transaction.signSignature
 			? transaction.signSignature
 			: undefined,


### PR DESCRIPTION
### What was the problem?
blockId didn't exist in the baseTransaction, but it was required in the core

### How did I fix it?
Add blockId to base transaction and transactionJSON
### How to test it?
`npm t`
### Review checklist

* The PR resolves #1173
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
