### PR TITLE
Integration test custom peer select functions - Closes1131

### DIFF
--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -347,6 +347,10 @@ export class P2P extends EventEmitter {
 
 				const wsPort: number = parseInt(queryObject.wsPort, BASE_10_RADIX);
 				const peerId = constructPeerId(socket.remoteAddress, wsPort);
+				const queryOptions =
+					typeof queryObject.options === 'string'
+						? JSON.parse(queryObject.options)
+						: undefined;
 
 				const incomingPeerInfo: P2PDiscoveredPeerInfo = {
 					...queryOptions,

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -347,10 +347,6 @@ export class P2P extends EventEmitter {
 
 				const wsPort: number = parseInt(queryObject.wsPort, BASE_10_RADIX);
 				const peerId = constructPeerId(socket.remoteAddress, wsPort);
-				const queryOptions =
-					typeof queryObject.options === 'string'
-						? JSON.parse(queryObject.options)
-						: undefined;
 
 				const incomingPeerInfo: P2PDiscoveredPeerInfo = {
 					...queryOptions,

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -13,7 +13,7 @@ describe('Integration tests for P2P library', () => {
 	const NETWORK_START_PORT = 5000;
 	const NETWORK_PEER_COUNT = 10;
 	const ALL_NODE_PORTS: ReadonlyArray<number> = [
-		...Array(NETWORK_PEER_COUNT).keys(),
+		...new Array(NETWORK_PEER_COUNT).keys(),
 	].map(index => NETWORK_START_PORT + index);
 	const NO_PEERS_FOUND_ERROR = `Request failed due to no peers found in peer selection`;
 
@@ -78,7 +78,7 @@ describe('Integration tests for P2P library', () => {
 		const DISCOVERY_INTERVAL = 200;
 
 		beforeEach(async () => {
-			p2pNodeList = [...Array(NETWORK_PEER_COUNT).keys()].map(index => {
+			p2pNodeList = [...new Array(NETWORK_PEER_COUNT).keys()].map(index => {
 				// Each node will have the next node in the sequence as a seed peer.
 				const seedPeers = [
 					{
@@ -310,7 +310,7 @@ describe('Integration tests for P2P library', () => {
 
 	describe('Fully connected network: Nodes are started gradually, one at a time. The seedPeers list of each node contains the previously launched node', () => {
 		beforeEach(async () => {
-			p2pNodeList = [...Array(NETWORK_PEER_COUNT).keys()].map(index => {
+			p2pNodeList = [...new Array(NETWORK_PEER_COUNT).keys()].map(index => {
 				// Each node will have the previous node in the sequence as a seed peer except the first node.
 				const seedPeers =
 					index === 0
@@ -695,8 +695,7 @@ describe('Integration tests for P2P library', () => {
 					if (
 						nodesModules &&
 						peerModules &&
-						nodesModules.filter(value => -1 !== peerModules.indexOf(value))
-							.length > 0
+						nodesModules.filter(value => peerModules.includes(value)).length > 0
 					) {
 						return true;
 					}
@@ -723,7 +722,7 @@ describe('Integration tests for P2P library', () => {
 		) => peersList;
 
 		beforeEach(async () => {
-			p2pNodeList = [...Array(NETWORK_PEER_COUNT).keys()].map(index => {
+			p2pNodeList = [...new Array(NETWORK_PEER_COUNT).keys()].map(index => {
 				// Each node will have the previous node in the sequence as a seed peer except the first node.
 				const seedPeers =
 					index === 0


### PR DESCRIPTION
### Description

Add Integration tests should contain the use of custom peer selection algorithm. In this way, we can be sure about the way we pass custom peer selection to the P2P constructor and its working.

It should cover tests for both,

`peerSelectForSendRequest`
`peerSelectForConnection`

### Review checklist

* The PR resolves #1131 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
