### PR TITLE
Fix timestamp validation - Closes #1179

### DIFF
--- a/packages/lisk-transactions/src/utils/validation/schema.ts
+++ b/packages/lisk-transactions/src/utils/validation/schema.ts
@@ -103,7 +103,7 @@ export const baseTransaction = {
 		},
 		timestamp: {
 			type: 'integer',
-			minimum: 0,
+			minimum: -2147483648,
 			maximum: 2147483647,
 		},
 		senderId: {
@@ -122,7 +122,7 @@ export const baseTransaction = {
 			type: 'string',
 		},
 		recipientPublicKey: {
-			type: ['string'],
+			type: 'string',
 			format: 'emptyOrPublicKey',
 		},
 		signature: {


### PR DESCRIPTION
### What was the problem?
Current protocol allows negative timestamp within int32

### How did I fix it?
Update the schema to allow negative number

### How to test it?
validate transaction with negative timestamp

### Review checklist

* The PR resolves #1179
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
