### PR TITLE
Fix undo to reset value not to strip - #Closes 1177

### DIFF
--- a/packages/lisk-transactions/src/1_second_signature_transaction.ts
+++ b/packages/lisk-transactions/src/1_second_signature_transaction.ts
@@ -209,14 +209,14 @@ export class SecondSignatureTransaction extends BaseTransaction {
 
 	protected undoAsset(store: StateStore): ReadonlyArray<TransactionError> {
 		const sender = store.account.get(this.senderId);
-		const strippedSender = {
+		const resetSender = {
 			...sender,
 			// tslint:disable-next-line no-null-keyword - Exception for compatibility with Core 1.4
 			secondPublicKey: null,
 			secondSignature: 0,
 		};
 
-		store.account.set(strippedSender.address, strippedSender);
+		store.account.set(resetSender.address, resetSender);
 
 		return [];
 	}

--- a/packages/lisk-transactions/src/2_delegate_transaction.ts
+++ b/packages/lisk-transactions/src/2_delegate_transaction.ts
@@ -224,8 +224,9 @@ export class DelegateTransaction extends BaseTransaction {
 		}
 		const updatedSender = {
 			...sender,
-			isDelegate: true,
 			username: this.asset.delegate.username,
+			vote: 0,
+			isDelegate: 1,
 		};
 		store.account.set(updatedSender.address, updatedSender);
 
@@ -235,7 +236,14 @@ export class DelegateTransaction extends BaseTransaction {
 	protected undoAsset(store: StateStore): ReadonlyArray<TransactionError> {
 		const sender = store.account.get(this.senderId);
 		const { username, ...strippedSender } = sender;
-		store.account.set(strippedSender.address, strippedSender);
+		const resetSender = {
+			...sender,
+			// tslint:disable-next-line no-null-keyword - Exception for compatibility with Core 1.4
+			username: null,
+			vote: 0,
+			isDelegate: 0,
+		};
+		store.account.set(strippedSender.address, resetSender);
 
 		return [];
 	}

--- a/packages/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/src/4_multisignature_transaction.ts
@@ -320,14 +320,14 @@ export class MultisignatureTransaction extends BaseTransaction {
 	protected undoAsset(store: StateStore): ReadonlyArray<TransactionError> {
 		const sender = store.account.get(this.senderId);
 
-		const {
-			membersPublicKeys,
-			multiMin,
-			multiLifetime,
-			...strippedSender
-		} = sender;
+		const resetSender = {
+			...sender,
+			membersPublicKeys: [],
+			multiMin: 0,
+			multiLifetime: 0,
+		};
 
-		store.account.set(strippedSender.address, strippedSender);
+		store.account.set(resetSender.address, resetSender);
 
 		return [];
 	}

--- a/packages/lisk-transactions/src/transaction_types.ts
+++ b/packages/lisk-transactions/src/transaction_types.ts
@@ -24,9 +24,10 @@ export interface Account {
 	readonly membersPublicKeys?: ReadonlyArray<string>;
 	readonly multiMin?: number;
 	readonly multiLifetime?: number;
-	readonly username?: string;
+	readonly username?: string | null;
 	readonly votedDelegatesPublicKeys?: ReadonlyArray<string>;
-	readonly isDelegate?: boolean;
+	readonly isDelegate?: number;
+	readonly vote?: number;
 }
 
 export interface Delegate {

--- a/packages/lisk-transactions/test/2_delegate_transaction.ts
+++ b/packages/lisk-transactions/test/2_delegate_transaction.ts
@@ -196,7 +196,8 @@ describe('Delegate registration transaction class', () => {
 			expect(storeAccountFindStub).to.be.calledOnce;
 			expect(storeAccountSetStub).to.be.calledWithExactly(sender.address, {
 				...sender,
-				isDelegate: true,
+				isDelegate: 1,
+				vote: 0,
 				username: validTestTransaction.asset.delegate.username,
 			});
 		});
@@ -226,15 +227,16 @@ describe('Delegate registration transaction class', () => {
 
 	describe('#undoAsset', () => {
 		it('should call state store', async () => {
-			const { isDelegate, username, ...strippedSender } = sender;
 			(validTestTransaction as any).undoAsset(store);
 			expect(storeAccountGetStub).to.be.calledWithExactly(
 				validTestTransaction.senderId,
 			);
-			expect(storeAccountSetStub).to.be.calledWithExactly(
-				sender.address,
-				strippedSender,
-			);
+			expect(storeAccountSetStub).to.be.calledWithExactly(sender.address, {
+				...sender,
+				isDelegate: 0,
+				vote: 0,
+				username: null,
+			});
 		});
 
 		it('should return no errors', async () => {

--- a/packages/lisk-transactions/test/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/test/4_multisignature_transaction.ts
@@ -393,7 +393,12 @@ describe('Multisignature transaction class', () => {
 			);
 			expect(storeAccountSetStub).to.be.calledWithExactly(
 				multisignatureSender.address,
-				nonMultisignatureSender,
+				{
+					...nonMultisignatureAccount,
+					membersPublicKeys: [],
+					multiLifetime: 0,
+					multiMin: 0,
+				},
 			);
 		});
 


### PR DESCRIPTION
### What was the problem?
Undo function was suppose to reset the value, not strip.

### How did I fix it?
Changed undo to update the value

### How to test it?
`npm t`

### Review checklist

* The PR resolves #1177
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
