### PR TITLE
Check for network, version, protocol compatibility during handshake - Closes#1137

### DIFF
--- a/packages/lisk-p2p/src/disconnect_status_codes.ts
+++ b/packages/lisk-p2p/src/disconnect_status_codes.ts
@@ -9,10 +9,10 @@ export const INVALID_CONNECTION_QUERY_REASON =
 export const INCOMPATIBLE_NETWORK_CODE = 4102;
 export const INCOMPATIBLE_NETWORK_REASON = 'Peer nethash did not match our own';
 
-export const INCOMPATIBLE_VERSION_CODE = 4103;
-export const INCOMPATIBLE_VERSION_REASON =
-	'Peer has incompatible or lower than the minimum version required';
-
-export const INCOMPATIBLE_PROTOCOL_VERSION_CODE = 4104;
+export const INCOMPATIBLE_PROTOCOL_VERSION_CODE = 4103;
 export const INCOMPATIBLE_PROTOCOL_VERSION_REASON =
 	'Peer has incompatible protocol version';
+
+export const INCOMPATIBLE_PEER_CODE = 4104;
+export const INCOMPATIBLE_PEER_UNKNOWN_REASON =
+	'Peer is incompatible with the node for unknown reasons';

--- a/packages/lisk-p2p/src/disconnect_status_codes.ts
+++ b/packages/lisk-p2p/src/disconnect_status_codes.ts
@@ -8,3 +8,11 @@ export const INVALID_CONNECTION_QUERY_REASON =
 
 export const INCOMPATIBLE_NETWORK_CODE = 4102;
 export const INCOMPATIBLE_NETWORK_REASON = 'Peer nethash did not match our own';
+
+export const INCOMPATIBLE_VERSION_CODE = 4103;
+export const INCOMPATIBLE_VERSION_REASON =
+	'Peer has incompatible or lower than the minimum version required';
+
+export const INCOMPATIBLE_PROTOCOL_VERSION_CODE = 4104;
+export const INCOMPATIBLE_PROTOCOL_VERSION_REASON =
+	'Peer has incompatible protocol version';

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -127,7 +127,7 @@ export class P2P extends EventEmitter {
 	private readonly _handleFailedPeerInfoUpdate: (error: Error) => void;
 	private readonly _handleOutboundSocketError: (error: Error) => void;
 	private readonly _handleInboundSocketError: (error: Error) => void;
-	private readonly _peerHandshakeChecks: P2PCheckPeerCompatibility;
+	private readonly _peerHandshakeCheck: P2PCheckPeerCompatibility;
 
 	public constructor(config: P2PConfig) {
 		super();
@@ -232,8 +232,8 @@ export class P2P extends EventEmitter {
 			? config.discoveryInterval
 			: DEFAULT_DISCOVERY_INTERVAL;
 
-		this._peerHandshakeChecks = config.peerhandShakeChecks
-			? config.peerhandShakeChecks
+		this._peerHandshakeCheck = config.peerHandshakeCheck
+			? config.peerHandshakeCheck
 			: checkPeerCompatibility;
 	}
 
@@ -350,7 +350,7 @@ export class P2P extends EventEmitter {
 					version: queryObject.version,
 				};
 
-				const { success, errors } = this._peerHandshakeChecks(
+				const { success, errors } = this._peerHandshakeCheck(
 					incomingPeerInfo,
 					this._nodeInfo,
 				);

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -379,7 +379,19 @@ export class P2P extends EventEmitter {
 					return;
 				}
 
-				if (!this._peerNetworkCompatibility(queryObject, this._nodeInfo)) {
+				const wsPort: number = parseInt(queryObject.wsPort, BASE_10_RADIX);
+				const peerId = constructPeerId(socket.remoteAddress, wsPort);
+				const queryOptions =
+					typeof queryObject.options === 'string'
+						? JSON.parse(queryObject.options)
+						: undefined;
+
+				if (
+					!this._peerNetworkCompatibility(
+						{ ...queryObject, ...queryOptions },
+						this._nodeInfo,
+					)
+				) {
 					socket.disconnect(
 						INCOMPATIBLE_NETWORK_CODE,
 						INCOMPATIBLE_NETWORK_REASON,
@@ -397,7 +409,12 @@ export class P2P extends EventEmitter {
 					return;
 				}
 
-				if (!this._peerVersionCompatibility(queryObject, this._nodeInfo)) {
+				if (
+					!this._peerVersionCompatibility(
+						{ ...queryObject, ...queryOptions },
+						this._nodeInfo,
+					)
+				) {
 					socket.disconnect(
 						INCOMPATIBLE_VERSION_CODE,
 						INCOMPATIBLE_VERSION_REASON,
@@ -416,7 +433,10 @@ export class P2P extends EventEmitter {
 				}
 
 				if (
-					!this._peerProtocolVersionCompatibility(queryObject, this._nodeInfo)
+					!this._peerProtocolVersionCompatibility(
+						{ ...queryObject, ...queryOptions },
+						this._nodeInfo,
+					)
 				) {
 					socket.disconnect(
 						INCOMPATIBLE_PROTOCOL_VERSION_CODE,
@@ -434,14 +454,6 @@ export class P2P extends EventEmitter {
 
 					return;
 				}
-
-				const wsPort: number = parseInt(queryObject.wsPort, BASE_10_RADIX);
-				const peerId = constructPeerId(socket.remoteAddress, wsPort);
-				const queryOptions =
-					typeof queryObject.options === 'string'
-						? JSON.parse(queryObject.options)
-						: undefined;
-
 				const incomingPeerInfo: P2PDiscoveredPeerInfo = {
 					...queryOptions,
 					...queryObject,

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -354,72 +354,69 @@ export class P2P extends EventEmitter {
 				}
 
 				if (this._peerHandShakeChecks) {
-					if (this._peerHandShakeChecks.networkCompatible) {
-						if (
-							!this._peerHandShakeChecks.networkCompatible(queryObject.nethash)
-						) {
-							socket.disconnect(
-								INCOMPATIBLE_NETWORK_CODE,
+					if (
+						this._peerHandShakeChecks.networkCompatible &&
+						!this._peerHandShakeChecks.networkCompatible(queryObject.nethash)
+					) {
+						socket.disconnect(
+							INCOMPATIBLE_NETWORK_CODE,
+							INCOMPATIBLE_NETWORK_REASON,
+						);
+						this.emit(
+							EVENT_FAILED_TO_ADD_INBOUND_PEER,
+							new PeerInboundHandshakeError(
 								INCOMPATIBLE_NETWORK_REASON,
-							);
-							this.emit(
-								EVENT_FAILED_TO_ADD_INBOUND_PEER,
-								new PeerInboundHandshakeError(
-									INCOMPATIBLE_NETWORK_REASON,
-									INCOMPATIBLE_NETWORK_CODE,
-									socket.remoteAddress,
-									socket.request.url,
-								),
-							);
+								INCOMPATIBLE_NETWORK_CODE,
+								socket.remoteAddress,
+								socket.request.url,
+							),
+						);
 
-							return;
-						}
+						return;
 					}
 
-					if (this._peerHandShakeChecks.versionCompatible) {
-						if (
-							!this._peerHandShakeChecks.versionCompatible(queryObject.version)
-						) {
-							socket.disconnect(
-								INCOMPATIBLE_VERSION_CODE,
+					if (
+						this._peerHandShakeChecks.versionCompatible &&
+						!this._peerHandShakeChecks.versionCompatible(queryObject.version)
+					) {
+						socket.disconnect(
+							INCOMPATIBLE_VERSION_CODE,
+							INCOMPATIBLE_VERSION_REASON,
+						);
+						this.emit(
+							EVENT_FAILED_TO_ADD_INBOUND_PEER,
+							new PeerInboundHandshakeError(
 								INCOMPATIBLE_VERSION_REASON,
-							);
-							this.emit(
-								EVENT_FAILED_TO_ADD_INBOUND_PEER,
-								new PeerInboundHandshakeError(
-									INCOMPATIBLE_VERSION_REASON,
-									INCOMPATIBLE_VERSION_CODE,
-									socket.remoteAddress,
-									socket.request.url,
-								),
-							);
+								INCOMPATIBLE_VERSION_CODE,
+								socket.remoteAddress,
+								socket.request.url,
+							),
+						);
 
-							return;
-						}
+						return;
 					}
 
-					if (this._peerHandShakeChecks.protocolVersionCompatible) {
-						if (
-							!this._peerHandShakeChecks.protocolVersionCompatible(
-								String(queryObject.protocolVersion),
-							)
-						) {
-							socket.disconnect(
-								INCOMPATIBLE_PROTOCOL_VERSION_CODE,
+					if (
+						this._peerHandShakeChecks.protocolVersionCompatible &&
+						!this._peerHandShakeChecks.protocolVersionCompatible(
+							String(queryObject.protocolVersion),
+						)
+					) {
+						socket.disconnect(
+							INCOMPATIBLE_PROTOCOL_VERSION_CODE,
+							INCOMPATIBLE_PROTOCOL_VERSION_REASON,
+						);
+						this.emit(
+							EVENT_FAILED_TO_ADD_INBOUND_PEER,
+							new PeerInboundHandshakeError(
 								INCOMPATIBLE_PROTOCOL_VERSION_REASON,
-							);
-							this.emit(
-								EVENT_FAILED_TO_ADD_INBOUND_PEER,
-								new PeerInboundHandshakeError(
-									INCOMPATIBLE_PROTOCOL_VERSION_REASON,
-									INCOMPATIBLE_PROTOCOL_VERSION_CODE,
-									socket.remoteAddress,
-									socket.request.url,
-								),
-							);
+								INCOMPATIBLE_PROTOCOL_VERSION_CODE,
+								socket.remoteAddress,
+								socket.request.url,
+							),
+						);
 
-							return;
-						}
+						return;
 					}
 				}
 

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -46,8 +46,10 @@ import {
 	P2PMessagePacket,
 	P2PNetworkStatus,
 	P2PNodeInfo,
-	P2PPeerCheckCompatibility,
 	P2PPeerInfo,
+	P2PPeerNetworkCompatibility,
+	P2PPeerProtocolVersionCompatibility,
+	P2PPeerVersionCompatibility,
 	P2PPenalty,
 	P2PRequestPacket,
 	P2PResponsePacket,
@@ -72,6 +74,11 @@ import {
 	EVENT_UPDATED_PEER_INFO,
 	PeerPool,
 } from './peer_pool';
+import {
+	checkNetworkCompatibility,
+	checkProtocolVersionCompatibility,
+	checkVersionCompatibility,
+} from './validation';
 
 export {
 	EVENT_CLOSE_OUTBOUND,
@@ -130,7 +137,9 @@ export class P2P extends EventEmitter {
 	private readonly _handleFailedPeerInfoUpdate: (error: Error) => void;
 	private readonly _handleOutboundSocketError: (error: Error) => void;
 	private readonly _handleInboundSocketError: (error: Error) => void;
-	private readonly _peerHandShakeChecks?: P2PPeerCheckCompatibility;
+	private readonly _peerNetworkCompatibility: P2PPeerNetworkCompatibility;
+	private readonly _peerVersionCompatibility: P2PPeerVersionCompatibility;
+	private readonly _peerProtocolVersionCompatibility: P2PPeerProtocolVersionCompatibility;
 
 	public constructor(config: P2PConfig) {
 		super();
@@ -235,7 +244,24 @@ export class P2P extends EventEmitter {
 			? config.discoveryInterval
 			: DEFAULT_DISCOVERY_INTERVAL;
 
-		this._peerHandShakeChecks = config.peerhandShakeChecks;
+		this._peerNetworkCompatibility = checkNetworkCompatibility;
+		this._peerVersionCompatibility = checkProtocolVersionCompatibility;
+		this._peerProtocolVersionCompatibility = checkVersionCompatibility;
+
+		if (config.peerhandShakeChecks) {
+			this._peerNetworkCompatibility = config.peerhandShakeChecks
+				.networkCompatible
+				? config.peerhandShakeChecks.networkCompatible
+				: checkNetworkCompatibility;
+			this._peerVersionCompatibility = config.peerhandShakeChecks
+				.protocolVersionCompatible
+				? config.peerhandShakeChecks.protocolVersionCompatible
+				: checkProtocolVersionCompatibility;
+			this._peerProtocolVersionCompatibility = config.peerhandShakeChecks
+				.versionCompatible
+				? config.peerhandShakeChecks.versionCompatible
+				: checkVersionCompatibility;
+		}
 	}
 
 	public get config(): P2PConfig {
@@ -353,71 +379,60 @@ export class P2P extends EventEmitter {
 					return;
 				}
 
-				if (this._peerHandShakeChecks) {
-					if (
-						this._peerHandShakeChecks.networkCompatible &&
-						!this._peerHandShakeChecks.networkCompatible(queryObject.nethash)
-					) {
-						socket.disconnect(
-							INCOMPATIBLE_NETWORK_CODE,
+				if (!this._peerNetworkCompatibility(queryObject, this._nodeInfo)) {
+					socket.disconnect(
+						INCOMPATIBLE_NETWORK_CODE,
+						INCOMPATIBLE_NETWORK_REASON,
+					);
+					this.emit(
+						EVENT_FAILED_TO_ADD_INBOUND_PEER,
+						new PeerInboundHandshakeError(
 							INCOMPATIBLE_NETWORK_REASON,
-						);
-						this.emit(
-							EVENT_FAILED_TO_ADD_INBOUND_PEER,
-							new PeerInboundHandshakeError(
-								INCOMPATIBLE_NETWORK_REASON,
-								INCOMPATIBLE_NETWORK_CODE,
-								socket.remoteAddress,
-								socket.request.url,
-							),
-						);
+							INCOMPATIBLE_NETWORK_CODE,
+							socket.remoteAddress,
+							socket.request.url,
+						),
+					);
 
-						return;
-					}
+					return;
+				}
 
-					if (
-						this._peerHandShakeChecks.versionCompatible &&
-						!this._peerHandShakeChecks.versionCompatible(queryObject.version)
-					) {
-						socket.disconnect(
-							INCOMPATIBLE_VERSION_CODE,
+				if (!this._peerVersionCompatibility(queryObject, this._nodeInfo)) {
+					socket.disconnect(
+						INCOMPATIBLE_VERSION_CODE,
+						INCOMPATIBLE_VERSION_REASON,
+					);
+					this.emit(
+						EVENT_FAILED_TO_ADD_INBOUND_PEER,
+						new PeerInboundHandshakeError(
 							INCOMPATIBLE_VERSION_REASON,
-						);
-						this.emit(
-							EVENT_FAILED_TO_ADD_INBOUND_PEER,
-							new PeerInboundHandshakeError(
-								INCOMPATIBLE_VERSION_REASON,
-								INCOMPATIBLE_VERSION_CODE,
-								socket.remoteAddress,
-								socket.request.url,
-							),
-						);
+							INCOMPATIBLE_VERSION_CODE,
+							socket.remoteAddress,
+							socket.request.url,
+						),
+					);
 
-						return;
-					}
+					return;
+				}
 
-					if (
-						this._peerHandShakeChecks.protocolVersionCompatible &&
-						!this._peerHandShakeChecks.protocolVersionCompatible(
-							String(queryObject.protocolVersion),
-						)
-					) {
-						socket.disconnect(
-							INCOMPATIBLE_PROTOCOL_VERSION_CODE,
+				if (
+					!this._peerProtocolVersionCompatibility(queryObject, this._nodeInfo)
+				) {
+					socket.disconnect(
+						INCOMPATIBLE_PROTOCOL_VERSION_CODE,
+						INCOMPATIBLE_PROTOCOL_VERSION_REASON,
+					);
+					this.emit(
+						EVENT_FAILED_TO_ADD_INBOUND_PEER,
+						new PeerInboundHandshakeError(
 							INCOMPATIBLE_PROTOCOL_VERSION_REASON,
-						);
-						this.emit(
-							EVENT_FAILED_TO_ADD_INBOUND_PEER,
-							new PeerInboundHandshakeError(
-								INCOMPATIBLE_PROTOCOL_VERSION_REASON,
-								INCOMPATIBLE_PROTOCOL_VERSION_CODE,
-								socket.remoteAddress,
-								socket.request.url,
-							),
-						);
+							INCOMPATIBLE_PROTOCOL_VERSION_CODE,
+							socket.remoteAddress,
+							socket.request.url,
+						),
+					);
 
-						return;
-					}
+					return;
 				}
 
 				const wsPort: number = parseInt(queryObject.wsPort, BASE_10_RADIX);

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -78,7 +78,7 @@ export interface P2PConfig {
 	readonly discoveryInterval?: number;
 	readonly peerSelectionForSendRequest?: P2PPeerSelectionForSendRequest;
 	readonly peerSelectionForConnection?: P2PPeerSelectionForConnection;
-	readonly peerhandShakeChecks?: P2PPeerCheckCompatibility;
+	readonly peerhandShakeChecks?: P2PCheckPeerCompatibility;
 }
 
 // Network info exposed by the P2P library.
@@ -120,7 +120,7 @@ export interface P2PCompatibilityCheckReturnType {
 }
 
 export type P2PCheckPeerCompatibility = (
-	headers: P2PInfoOptions,
+	headers: P2PDiscoveredPeerInfo,
 	nodeInfo: P2PNodeInfo,
 ) => P2PCompatibilityCheckReturnType;
 

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -78,7 +78,7 @@ export interface P2PConfig {
 	readonly discoveryInterval?: number;
 	readonly peerSelectionForSendRequest?: P2PPeerSelectionForSendRequest;
 	readonly peerSelectionForConnection?: P2PPeerSelectionForConnection;
-	readonly peerhandShakeChecks?: P2PCheckPeerCompatibility;
+	readonly peerHandshakeCheck?: P2PCheckPeerCompatibility;
 }
 
 // Network info exposed by the P2P library.

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -1,5 +1,3 @@
-import { ParsedUrlQuery } from 'querystring';
-
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -123,15 +121,15 @@ export interface P2PPeerCheckCompatibility {
 }
 
 export type P2PPeerNetworkCompatibility = (
-	headers: ParsedUrlQuery,
+	headers: P2PInfoOptions,
 	nodeInfo: P2PNodeInfo,
 ) => boolean;
 export type P2PPeerProtocolVersionCompatibility = (
-	headers: ParsedUrlQuery,
+	headers: P2PInfoOptions,
 	nodeInfo: P2PNodeInfo,
 ) => boolean;
 export type P2PPeerVersionCompatibility = (
-	headers: ParsedUrlQuery,
+	headers: P2PInfoOptions,
 	nodeInfo: P2PNodeInfo,
 ) => boolean;
 

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -113,6 +113,18 @@ export type P2PPeerSelectionForConnection = (
 	nodeInfo?: P2PNodeInfo,
 ) => ReadonlyArray<P2PDiscoveredPeerInfo>;
 
+export interface P2PPeerCheckCompatibility {
+	readonly networkCompatible: P2PPeerNetworkCompatibility;
+	readonly protocolVersionCompatible: P2PPeerProtocolVersionCompatibility;
+	readonly versionCompatible: P2PPeerVersionCompatibility;
+}
+
+export type P2PPeerNetworkCompatibility = (nethash: string) => boolean;
+export type P2PPeerProtocolVersionCompatibility = (
+	protocolVersion: string,
+) => boolean;
+export type P2PPeerVersionCompatibility = (version: string) => boolean;
+
 // This is a representation of the inbound peer object according to the current protocol.
 // TODO later: Switch to LIP protocol format.
 export interface ProtocolPeerInfo {

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -114,24 +114,15 @@ export type P2PPeerSelectionForConnection = (
 	nodeInfo?: P2PNodeInfo,
 ) => ReadonlyArray<P2PDiscoveredPeerInfo>;
 
-export interface P2PPeerCheckCompatibility {
-	readonly networkCompatible?: P2PPeerNetworkCompatibility;
-	readonly protocolVersionCompatible?: P2PPeerProtocolVersionCompatibility;
-	readonly versionCompatible?: P2PPeerVersionCompatibility;
+export interface P2PCompatibilityCheckReturnType {
+	readonly success: boolean;
+	readonly errors?: string[];
 }
 
-export type P2PPeerNetworkCompatibility = (
+export type P2PCheckPeerCompatibility = (
 	headers: P2PInfoOptions,
 	nodeInfo: P2PNodeInfo,
-) => boolean;
-export type P2PPeerProtocolVersionCompatibility = (
-	headers: P2PInfoOptions,
-	nodeInfo: P2PNodeInfo,
-) => boolean;
-export type P2PPeerVersionCompatibility = (
-	headers: P2PInfoOptions,
-	nodeInfo: P2PNodeInfo,
-) => boolean;
+) => P2PCompatibilityCheckReturnType;
 
 // This is a representation of the inbound peer object according to the current protocol.
 // TODO later: Switch to LIP protocol format.

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -78,6 +78,7 @@ export interface P2PConfig {
 	readonly discoveryInterval?: number;
 	readonly peerSelectionForSendRequest?: P2PPeerSelectionForSendRequest;
 	readonly peerSelectionForConnection?: P2PPeerSelectionForConnection;
+	readonly peerhandShakeChecks?: P2PPeerCheckCompatibility;
 }
 
 // Network info exposed by the P2P library.
@@ -114,9 +115,9 @@ export type P2PPeerSelectionForConnection = (
 ) => ReadonlyArray<P2PDiscoveredPeerInfo>;
 
 export interface P2PPeerCheckCompatibility {
-	readonly networkCompatible: P2PPeerNetworkCompatibility;
-	readonly protocolVersionCompatible: P2PPeerProtocolVersionCompatibility;
-	readonly versionCompatible: P2PPeerVersionCompatibility;
+	readonly networkCompatible?: P2PPeerNetworkCompatibility;
+	readonly protocolVersionCompatible?: P2PPeerProtocolVersionCompatibility;
+	readonly versionCompatible?: P2PPeerVersionCompatibility;
 }
 
 export type P2PPeerNetworkCompatibility = (nethash: string) => boolean;

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -1,3 +1,5 @@
+import { ParsedUrlQuery } from 'querystring';
+
 /*
  * Copyright © 2018 Lisk Foundation
  *
@@ -120,11 +122,18 @@ export interface P2PPeerCheckCompatibility {
 	readonly versionCompatible?: P2PPeerVersionCompatibility;
 }
 
-export type P2PPeerNetworkCompatibility = (nethash: string) => boolean;
-export type P2PPeerProtocolVersionCompatibility = (
-	protocolVersion: string,
+export type P2PPeerNetworkCompatibility = (
+	headers: ParsedUrlQuery,
+	nodeInfo: P2PNodeInfo,
 ) => boolean;
-export type P2PPeerVersionCompatibility = (version: string) => boolean;
+export type P2PPeerProtocolVersionCompatibility = (
+	headers: ParsedUrlQuery,
+	nodeInfo: P2PNodeInfo,
+) => boolean;
+export type P2PPeerVersionCompatibility = (
+	headers: ParsedUrlQuery,
+	nodeInfo: P2PNodeInfo,
+) => boolean;
 
 // This is a representation of the inbound peer object according to the current protocol.
 // TODO later: Switch to LIP protocol format.

--- a/packages/lisk-p2p/src/validation.ts
+++ b/packages/lisk-p2p/src/validation.ts
@@ -21,9 +21,9 @@ import {
 	InvalidRPCResponseError,
 } from './errors';
 
-import { ParsedUrlQuery } from 'querystring';
 import {
 	P2PDiscoveredPeerInfo,
+	P2PInfoOptions,
 	P2PNodeInfo,
 	ProtocolMessagePacket,
 	ProtocolPeerInfo,
@@ -141,29 +141,29 @@ export const validateProtocolMessage = (
 };
 
 export const checkNetworkCompatibility = (
-	header: ParsedUrlQuery,
+	headers: P2PInfoOptions,
 	nodeInfo: P2PNodeInfo,
 ): boolean => {
-	if (!header.nethash) {
+	if (!headers.nethash) {
 		return false;
 	}
 
-	return header.nethash === nodeInfo.nethash;
+	return headers.nethash === nodeInfo.nethash;
 };
 
 export const checkVersionCompatibility = (
-	header: ParsedUrlQuery,
+	headers: P2PInfoOptions,
 	nodeInfo: P2PNodeInfo,
 ): boolean => {
-	if (!header.version) {
+	if (!headers.version) {
 		return false;
 	}
 
-	return gte(header.version as string, nodeInfo.minVersion as string);
+	return gte(headers.version as string, nodeInfo.minVersion as string);
 };
 
 export const checkProtocolVersionCompatibility = (
-	headers: ParsedUrlQuery,
+	headers: P2PInfoOptions,
 	nodeInfo: P2PNodeInfo,
 ): boolean => {
 	if (!headers.protocolVersion) {

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -31,7 +31,9 @@ describe('Integration tests for P2P library', () => {
 						wsPort: nodePort,
 						nethash:
 							'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
-						version: '1.0.0',
+						version: '1.0.1',
+						protocolVersion: '1.0.1',
+						minVersion: '1.0.0',
 						os: platform(),
 						height: 0,
 						broadhash:
@@ -100,7 +102,9 @@ describe('Integration tests for P2P library', () => {
 						wsPort: NETWORK_START_PORT + index,
 						nethash:
 							'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
-						version: '1.0.0',
+						minVersion: '1.0.0',
+						version: '1.0.1',
+						protocolVersion: '1.0.1',
 						os: platform(),
 						height: 0,
 						broadhash:
@@ -332,7 +336,9 @@ describe('Integration tests for P2P library', () => {
 						wsPort: NETWORK_START_PORT + index,
 						nethash:
 							'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
-						version: '1.0.0',
+						version: '1.0.1',
+						protocolVersion: '1.0.1',
+						minVersion: '1.0.0',
 						os: platform(),
 						height: 0,
 						broadhash:

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -102,7 +102,7 @@ describe('Integration tests for P2P library', () => {
 						wsPort: NETWORK_START_PORT + index,
 						nethash:
 							'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
-						minVersion: '1.0.0',
+						minVersion: '1.0.1',
 						version: '1.0.1',
 						protocolVersion: '1.0.1',
 						os: platform(),
@@ -910,7 +910,9 @@ describe('Integration tests for P2P library', () => {
 						wsPort: NETWORK_START_PORT + index,
 						nethash:
 							'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
-						version: '1.0.0',
+						version: '1.0.1',
+						protocolVersion: '1.0.1',
+						minVersion: '1.0.0',
 						os: platform(),
 						height: 0,
 						broadhash:

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -753,7 +753,8 @@ describe('Integration tests for P2P library', () => {
 						wsPort: NETWORK_START_PORT + index,
 						nethash:
 							'da3ed6a45429278bac2666961289ca17ad86595d33b31037615d4b8e8f158bba',
-						version: '1.0.0',
+						version: '1.0.1',
+						protocolVersion: '1.0.1',
 						os: platform(),
 						height: 1000 + index,
 						broadhash:


### PR DESCRIPTION
### Description

Add a field in P2P config to allow compatibility check functions to be inserted in the constructor. The checks will cover,

- Network compatibility (`nethash`)
- Version compatibility (`version`)
- Protocol version compatibility (`protocolVersion`)

### Review checklist

* The PR resolves #1137 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
