### PR TITLE
Update existsInTransactionPool function parameters and use id instead of transaction object 

### DIFF
--- a/packages/lisk-transaction-pool/src/queue.ts
+++ b/packages/lisk-transaction-pool/src/queue.ts
@@ -84,8 +84,8 @@ export class Queue {
 		this._index[transaction.id] = transaction;
 	}
 
-	public exists(transaction: Transaction): boolean {
-		return !!this._index[transaction.id];
+	public exists(id: string): boolean {
+		return !!this._index[id];
 	}
 
 	public filter(

--- a/packages/lisk-transaction-pool/src/transaction_pool.ts
+++ b/packages/lisk-transaction-pool/src/transaction_pool.ts
@@ -294,10 +294,10 @@ export class TransactionPool extends EventEmitter {
 		};
 	}
 
-	public existsInTransactionPool(transaction: Transaction): boolean {
+	public existsInTransactionPool(id: string): boolean {
 		return Object.keys(this._queues).reduce(
 			(previousValue, queueName) =>
-				previousValue || this._queues[queueName].exists(transaction),
+				previousValue || this._queues[queueName].exists(id),
 			false,
 		);
 	}
@@ -429,7 +429,7 @@ export class TransactionPool extends EventEmitter {
 		queueName: QueueNames,
 		transaction: Transaction,
 	): AddTransactionResult {
-		if (this.existsInTransactionPool(transaction)) {
+		if (this.existsInTransactionPool(transaction.id)) {
 			return {
 				isFull: false,
 				alreadyExists: true,

--- a/packages/lisk-transaction-pool/test/integration/transaction_movement.ts
+++ b/packages/lisk-transaction-pool/test/integration/transaction_movement.ts
@@ -86,7 +86,7 @@ describe('transaction movement between queues', () => {
 		it('should remove transactions from the received queue', async () => {
 			await wrapExpectationInNextTick(() => {
 				transactionsToValidate.forEach(transaction => {
-					expect(transactionPool.queues.received.exists(transaction)).to.be
+					expect(transactionPool.queues.received.exists(transaction.id)).to.be
 						.false;
 				});
 			});
@@ -95,7 +95,7 @@ describe('transaction movement between queues', () => {
 		it('should move valid transactions to the validated queue', async () => {
 			await wrapExpectationInNextTick(() => {
 				validTransactions.forEach(transaction => {
-					expect(transactionPool.queues.validated.exists(transaction)).to.be
+					expect(transactionPool.queues.validated.exists(transaction.id)).to.be
 						.true;
 				});
 				expect(transactionPool.queues.validated.size()).to.equal(
@@ -107,7 +107,7 @@ describe('transaction movement between queues', () => {
 		it('should remove invalid transactions from the transaction pool', async () => {
 			await wrapExpectationInNextTick(() => {
 				invalidTransactions.forEach(transaction => {
-					expect(transactionPool.existsInTransactionPool(transaction)).to.be
+					expect(transactionPool.existsInTransactionPool(transaction.id)).to.be
 						.false;
 				});
 			});
@@ -133,8 +133,8 @@ describe('transaction movement between queues', () => {
 			it('should remove transactions from the validated queue', async () => {
 				await wrapExpectationInNextTick(() => {
 					transactionsToVerify.forEach(transaction => {
-						expect(transactionPool.queues.validated.exists(transaction)).to.be
-							.false;
+						expect(transactionPool.queues.validated.exists(transaction.id)).to
+							.be.false;
 					});
 				});
 			});
@@ -142,7 +142,7 @@ describe('transaction movement between queues', () => {
 			it('should move verified transactions to the verified queue', async () => {
 				await wrapExpectationInNextTick(() => {
 					verifiableTransactions.forEach(transaction => {
-						expect(transactionPool.queues.verified.exists(transaction)).to.be
+						expect(transactionPool.queues.verified.exists(transaction.id)).to.be
 							.true;
 					});
 					expect(transactionPool.queues.verified.size()).to.equal(
@@ -154,8 +154,8 @@ describe('transaction movement between queues', () => {
 			it('should remove verified transactions from the transaction pool', async () => {
 				await wrapExpectationInNextTick(() => {
 					unverifiableTransactions.forEach(transaction => {
-						expect(transactionPool.existsInTransactionPool(transaction)).to.be
-							.false;
+						expect(transactionPool.existsInTransactionPool(transaction.id)).to
+							.be.false;
 					});
 				});
 			});
@@ -180,8 +180,8 @@ describe('transaction movement between queues', () => {
 				it('should remove transactions from the verified queue', async () => {
 					await wrapExpectationInNextTick(() => {
 						transactionsToProcess.forEach(transaction => {
-							expect(transactionPool.queues.verified.exists(transaction)).to.be
-								.false;
+							expect(transactionPool.queues.verified.exists(transaction.id)).to
+								.be.false;
 						});
 					});
 				});
@@ -189,7 +189,7 @@ describe('transaction movement between queues', () => {
 				it('should move processable transactions to the ready queue', async () => {
 					await wrapExpectationInNextTick(() => {
 						processableTransactions.forEach(transaction => {
-							expect(transactionPool.queues.ready.exists(transaction)).to.be
+							expect(transactionPool.queues.ready.exists(transaction.id)).to.be
 								.true;
 						});
 						expect(transactionPool.queues.ready.size()).to.equal(
@@ -201,8 +201,8 @@ describe('transaction movement between queues', () => {
 				it('should remove unverfied transactions from the transaction pool', async () => {
 					await wrapExpectationInNextTick(() => {
 						unprocessableTransactions.forEach(transaction => {
-							expect(transactionPool.existsInTransactionPool(transaction)).to.be
-								.false;
+							expect(transactionPool.existsInTransactionPool(transaction.id)).to
+								.be.false;
 						});
 					});
 				});
@@ -217,7 +217,7 @@ describe('transaction movement between queues', () => {
 
 					await wrapExpectationInNextTick(() => {
 						transactionsInReadyQueue.forEach(transaction => {
-							expect(transactionPool.queues.ready.exists(transaction)).to.be
+							expect(transactionPool.queues.ready.exists(transaction.id)).to.be
 								.true;
 						});
 					});

--- a/packages/lisk-transaction-pool/test/integration/transaction_pool_events.ts
+++ b/packages/lisk-transaction-pool/test/integration/transaction_pool_events.ts
@@ -137,44 +137,46 @@ describe('transaction pool events', () => {
 
 			it('should move affected transactions in verified, pending and ready queue to the validated queue', async () => {
 				transactionsToMoveToValidatedQueue.forEach(affectedTransaction => {
-					expect(transactionPool.queues.validated.exists(affectedTransaction))
-						.to.be.true;
+					expect(
+						transactionPool.queues.validated.exists(affectedTransaction.id),
+					).to.be.true;
 				});
 			});
 
 			it('should move affected transactions in the validated queue to the received queue', async () => {
 				transactionsToMoveToReceivedQueue.forEach(affectedTransaction => {
-					expect(transactionPool.queues.received.exists(affectedTransaction)).to
-						.be.true;
+					expect(transactionPool.queues.received.exists(affectedTransaction.id))
+						.to.be.true;
 				});
 			});
 
 			it('should keep the unaffected transactions in their queues', async () => {
 				unaffectedTransactionsInReadyQueue.forEach(
 					transaction =>
-						expect(transactionPool.queues.ready.exists(transaction)).to.be.true,
+						expect(transactionPool.queues.ready.exists(transaction.id)).to.be
+							.true,
 				);
 				unaffectedTransactionsInVerifiedQueue.forEach(
 					transaction =>
-						expect(transactionPool.queues.verified.exists(transaction)).to.be
+						expect(transactionPool.queues.verified.exists(transaction.id)).to.be
 							.true,
 				);
 				unaffectedTransactionsInPendingQueue.forEach(
 					transaction =>
-						expect(transactionPool.queues.pending.exists(transaction)).to.be
+						expect(transactionPool.queues.pending.exists(transaction.id)).to.be
 							.true,
 				);
 				unaffectedTransactionsInValidatedQueue.forEach(
 					transaction =>
-						expect(transactionPool.queues.validated.exists(transaction)).to.be
-							.true,
+						expect(transactionPool.queues.validated.exists(transaction.id)).to
+							.be.true,
 				);
 			});
 
 			it('should add transactions to the verified queue', async () => {
 				transactionsToAffectedReceipients.forEach(
 					transaction =>
-						expect(transactionPool.queues.verified.exists(transaction)).to.be
+						expect(transactionPool.queues.verified.exists(transaction.id)).to.be
 							.true,
 				);
 			});
@@ -254,21 +256,21 @@ describe('transaction pool events', () => {
 
 			it('should remove confirmed transactions from the transaction pool', async () => {
 				confirmedTransactions.forEach(transaction => {
-					expect(transactionPool.existsInTransactionPool(transaction)).to.be
+					expect(transactionPool.existsInTransactionPool(transaction.id)).to.be
 						.false;
 				});
 			});
 
 			it('should move affected transactions in the verified, ready and pending queue to the validated queue', async () => {
 				transactionsToMoveToValidatedQueue.forEach(transaction => {
-					expect(transactionPool.queues.validated.exists(transaction)).to.be
+					expect(transactionPool.queues.validated.exists(transaction.id)).to.be
 						.true;
 				});
 			});
 
 			it('should move affected transactions in the validated queue to the received queue', async () => {
 				transactionsToMoveToReceivedQueue.forEach(transaction => {
-					expect(transactionPool.queues.received.exists(transaction)).to.be
+					expect(transactionPool.queues.received.exists(transaction.id)).to.be
 						.true;
 				});
 			});
@@ -303,14 +305,14 @@ describe('transaction pool events', () => {
 
 			it('should move affected transactions in the validated queue to the received queue', async () => {
 				transactionsToMoveToReceivedQueue.forEach(transaction => {
-					expect(transactionPool.queues.received.exists(transaction)).to.be
+					expect(transactionPool.queues.received.exists(transaction.id)).to.be
 						.true;
 				});
 			});
 
 			it('should move affected transactions in the verified, ready and pending queue to the validated queue', async () => {
 				transactionsToMoveToValidatedQueue.forEach(transaction => {
-					expect(transactionPool.queues.validated.exists(transaction)).to.be
+					expect(transactionPool.queues.validated.exists(transaction.id)).to.be
 						.true;
 				});
 			});

--- a/packages/lisk-transaction-pool/test/unit/queue.ts
+++ b/packages/lisk-transaction-pool/test/unit/queue.ts
@@ -62,12 +62,12 @@ describe('Queue', () => {
 		it('should return true if transaction exists in queue', async () => {
 			const transaction = transactions[0];
 			queue.enqueueOne(transaction);
-			expect(queue.exists(transaction)).to.be.true;
+			expect(queue.exists(transaction.id)).to.be.true;
 		});
 
 		it('should return false if transaction does not exist in queue', async () => {
 			const transaction = transactions[0];
-			expect(queue.exists(transaction)).to.be.false;
+			expect(queue.exists(transaction.id)).to.be.false;
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?
The existsInTransactionPool parameter was the transaction object, instead, it should have been transaction id.
### How did I fix it?
Updated the existsInTransactionPool parameter, and used `id` as the parameter instead.
### How to test it?
Run tests
### Review checklist

* The PR resolves #1190 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
