### PR TITLE
Default to pending for multisig registration transaction - Closes #1192

### DIFF
--- a/packages/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/src/4_multisignature_transaction.ts
@@ -99,6 +99,9 @@ export interface MultiSignatureAsset {
 
 export class MultisignatureTransaction extends BaseTransaction {
 	public readonly asset: MultiSignatureAsset;
+	protected _multisignatureStatus: MultisignatureStatus =
+		MultisignatureStatus.PENDING;
+
 	public constructor(tx: TransactionJSON) {
 		super(tx);
 		const typeValid = validator.validate(

--- a/packages/lisk-transactions/test/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/test/4_multisignature_transaction.ts
@@ -79,6 +79,10 @@ describe('Multisignature transaction class', () => {
 			);
 		});
 
+		it('should set _multisignatureStatus to PENDING', async () => {
+			expect(validTestTransaction).to.have.property('_multisignatureStatus', 2);
+		});
+
 		it('should throw TransactionMultiError when asset min is not a number', async () => {
 			const invalidMultisignatureTransactionData = {
 				...validMultisignatureTransaction,


### PR DESCRIPTION
### What was the problem?

For type 4 multisig registration transaction, status was set to UNKNOWN by default. Since we know it's multisig, it should be set to PENDING instead.

### How did I fix it?

Set multisig status to PENDING(2) by default.

### How to test it?

npm run test

### Review checklist

* The PR resolves #1192
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
