### PR TITLE
Fix the order of elements returned from peekUntil and dequeueUntil - Closes #1195

### DIFF
--- a/packages/lisk-transaction-pool/src/queue.ts
+++ b/packages/lisk-transaction-pool/src/queue.ts
@@ -54,7 +54,7 @@ export class Queue {
 				delete this._index[transaction.id];
 
 				return {
-					affected: [transaction, ...affected],
+					affected: [...affected, transaction],
 					unaffected,
 					conditionFailedOnce: false,
 				};
@@ -112,7 +112,7 @@ export class Queue {
 				}
 
 				return {
-					affected: [transaction, ...affected],
+					affected: [...affected, transaction],
 					unaffected,
 					conditionFailedOnce: false,
 				};

--- a/packages/lisk-transaction-pool/test/unit/queue.ts
+++ b/packages/lisk-transaction-pool/test/unit/queue.ts
@@ -170,8 +170,8 @@ describe('Queue', () => {
 
 			const peekedTransactions = queue.peekUntil(condition);
 			expect(peekedTransactions).to.deep.equal([
-				secondToLastTransaciton,
 				lastTransaction,
+				secondToLastTransaciton,
 			]);
 		});
 	});
@@ -202,8 +202,8 @@ describe('Queue', () => {
 
 			const dequeuedTransactions = queue.dequeueUntil(condition);
 			expect(dequeuedTransactions).to.deep.equal([
-				secondToLastTransaciton,
 				lastTransaction,
+				secondToLastTransaciton,
 			]);
 		});
 


### PR DESCRIPTION
### What was the problem?
The PeekUntil and DequeueUntil should return transactions ordered from youngest to oldest.
### How did I fix it?
Fixed the reduce function to add the oldest elements in the beginning of the array.
### How to test it?
Run the tests.
### Review checklist

* The PR resolves #1195 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
