### PR TITLE
Remove the requirement for recipient_public_key property for vote transaction

### DIFF
--- a/packages/lisk-transactions/src/3_vote_transaction.ts
+++ b/packages/lisk-transactions/src/3_vote_transaction.ts
@@ -202,16 +202,6 @@ export class VoteTransaction extends BaseTransaction {
 			);
 		}
 
-		if (!this.recipientPublicKey) {
-			errors.push(
-				new TransactionError(
-					'RecipientPublicKey must be set for vote transaction',
-					this.id,
-					'.recipientPublicKey',
-				),
-			);
-		}
-
 		return errors;
 	}
 

--- a/packages/lisk-transactions/test/3_vote_transaction.ts
+++ b/packages/lisk-transactions/test/3_vote_transaction.ts
@@ -279,18 +279,6 @@ describe('Vote transaction class', () => {
 			expect(errors).not.to.be.empty;
 			expect(errors[0].dataPath).to.be.equal('.recipientId');
 		});
-
-		it('should return error when recipientPublicKey is empty', async () => {
-			const invalidTransaction = {
-				...validVoteTransactions[2],
-				recipientPublicKey: '',
-			};
-			const transaction = new VoteTransaction(invalidTransaction);
-
-			const errors = (transaction as any).validateAsset();
-			expect(errors).not.to.be.empty;
-			expect(errors[0].dataPath).to.be.equal('.recipientPublicKey');
-		});
 	});
 
 	describe('#applyAsset', () => {


### PR DESCRIPTION
### What was the problem?
The `recipient_public_key` was required for vote transaction in lisk-transactions, but it's not required by the protocol.
### How did I fix it?
Removed the restriction, and the relevant tests.
### How to test it?
Run the tests.
### Review checklist

* The PR resolves #1201 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
