### PR TITLE
Convert optional field null to undefined

### DIFF
--- a/packages/lisk-transactions/src/5_dapp_transaction.ts
+++ b/packages/lisk-transactions/src/5_dapp_transaction.ts
@@ -27,12 +27,15 @@ const TRANSACTION_DAPP_TYPE = 5;
 export interface DappAsset {
 	readonly dapp: {
 		readonly category: number;
-		readonly description?: string;
-		readonly icon?: string;
 		readonly link: string;
 		readonly name: string;
-		readonly tags?: string;
 		readonly type: number;
+		// tslint:disable-next-line readonly-keyword
+		description?: string;
+		// tslint:disable-next-line readonly-keyword
+		icon?: string;
+		// tslint:disable-next-line readonly-keyword
+		tags?: string;
 	};
 }
 
@@ -97,6 +100,10 @@ export class DappTransaction extends BaseTransaction {
 			: {}) as Partial<TransactionJSON>;
 
 		this.asset = (tx.asset || { dapp: {} }) as DappAsset;
+		// If Optional field contains null, converts to undefined
+		this.asset.dapp.description = this.asset.dapp.description || undefined;
+		this.asset.dapp.icon = this.asset.dapp.icon || undefined;
+		this.asset.dapp.tags = this.asset.dapp.tags || undefined;
 		this.containsUniqueData = true;
 	}
 

--- a/packages/lisk-transactions/test/5_dapp_transaction.ts
+++ b/packages/lisk-transactions/test/5_dapp_transaction.ts
@@ -196,6 +196,23 @@ describe('Dapp transaction class', () => {
 			expect(errors).to.be.an('array').and.empty;
 		});
 
+		it('should not return error when optional field contains null', async () => {
+			const validTransaction = {
+				...defaultValidDappTransaction,
+				asset: {
+					dapp: {
+						...defaultValidDappTransaction.asset.dapp,
+						description: null,
+						icon: null,
+						tags: null,
+					},
+				},
+			};
+			const transaction = new DappTransaction(validTransaction);
+			const errors = (transaction as any).validateAsset();
+			expect(errors).to.be.empty;
+		});
+
 		it('should return error when amount is not zero', async () => {
 			const invalidTransaction = {
 				...defaultValidDappTransaction,


### PR DESCRIPTION
### What was the problem?
Optional field should accept null and undefined for the validation

### How did I fix it?
In constructor, change the null to undefined

### How to test it?
npm t

### Review checklist

* The PR resolves #1203 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
