### PR TITLE
Improve error datapath for vote transaction

### DIFF
--- a/packages/lisk-transactions/src/3_vote_transaction.ts
+++ b/packages/lisk-transactions/src/3_vote_transaction.ts
@@ -219,7 +219,11 @@ export class VoteTransaction extends BaseTransaction {
 					(voteAccount.username === undefined || voteAccount.username === ''))
 			) {
 				errors.push(
-					new TransactionError(`${vote} is not a delegate.`, this.id),
+					new TransactionError(
+						`${vote} is not a delegate.`,
+						this.id,
+						'.asset.votes',
+					),
 				);
 			}
 		});
@@ -230,12 +234,20 @@ export class VoteTransaction extends BaseTransaction {
 			// Check duplicate votes
 			if (action === PREFIX_UPVOTE && senderVotes.includes(publicKey)) {
 				errors.push(
-					new TransactionError(`${publicKey} is already voted.`, this.id),
+					new TransactionError(
+						`${publicKey} is already voted.`,
+						this.id,
+						'.asset.votes',
+					),
 				);
 				// Check non-existing unvotes
 			} else if (action === PREFIX_UNVOTE && !senderVotes.includes(publicKey)) {
 				errors.push(
-					new TransactionError(`${publicKey} is not voted.`, this.id),
+					new TransactionError(
+						`${publicKey} is not voted.`,
+						this.id,
+						'.asset.votes',
+					),
 				);
 			}
 		});
@@ -257,6 +269,7 @@ export class VoteTransaction extends BaseTransaction {
 						votedDelegatesPublicKeys.length
 					}.`,
 					this.id,
+					'.asset.votes',
 					votedDelegatesPublicKeys.length.toString(),
 					MAX_VOTE_PER_ACCOUNT,
 				),
@@ -292,6 +305,7 @@ export class VoteTransaction extends BaseTransaction {
 						votedDelegatesPublicKeys.length
 					}.`,
 					this.id,
+					'.asset.votes',
 					votedDelegatesPublicKeys.length.toString(),
 					MAX_VOTE_PER_ACCOUNT,
 				),

--- a/packages/lisk-transactions/test/3_vote_transaction.ts
+++ b/packages/lisk-transactions/test/3_vote_transaction.ts
@@ -329,6 +329,7 @@ describe('Vote transaction class', () => {
 			const errors = (validTestTransaction as any).applyAsset(store);
 			expect(errors).not.to.be.empty;
 			expect(errors[0].message).to.contain('is already voted.');
+			expect(errors[0].dataPath).equal('.asset.votes');
 		});
 
 		it('should return error when vote exceeds maximum votes', async () => {
@@ -345,6 +346,7 @@ describe('Vote transaction class', () => {
 			expect(errors[0].message).to.contains(
 				'Vote cannot exceed 101 but has 102.',
 			);
+			expect(errors[0].dataPath).equal('.asset.votes');
 		});
 	});
 


### PR DESCRIPTION
### What was the problem?
error for applying vote transaction didn't include dataPath

### How did I fix it?
Include datapath when returning error for vote transaction

### How to test it?
npm t

### Review checklist

* The PR resolves #1206 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
