### PR TITLE
Integration tests failing randomly due to low timeout - Closes#1103

### DIFF
--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -330,6 +330,7 @@ describe('Integration tests for P2P library', () => {
 				return new P2P({
 					blacklistedPeers: [],
 					connectTimeout: 5000,
+					ackTimeout: 5000,
 					seedPeers,
 					wsEngine: 'ws',
 					nodeInfo: {
@@ -682,7 +683,6 @@ describe('Integration tests for P2P library', () => {
 	});
 
 	describe('Connected network: User custom selection algorithm is passed to each node', () => {
-		const DISCOVERY_INTERVAL = 200;
 		// Custom selection function that finds peers having common values for modules field for example.
 		const peerSelectionForSendRequest: P2PPeerSelectionForSendRequest = (
 			peersList: ReadonlyArray<P2PDiscoveredPeerInfo>,
@@ -744,9 +744,9 @@ describe('Integration tests for P2P library', () => {
 				return new P2P({
 					blacklistedPeers: [],
 					connectTimeout: 5000,
+					ackTimeout: 5000,
 					peerSelectionForSendRequest,
 					peerSelectionForConnection,
-					discoveryInterval: DISCOVERY_INTERVAL,
 					seedPeers,
 					wsEngine: 'ws',
 					nodeInfo: {
@@ -903,8 +903,8 @@ describe('Integration tests for P2P library', () => {
 					seedPeers,
 					wsEngine: 'ws',
 					// A short connectTimeout and ackTimeout will make the node to give up on discovery quicker for our test.
-					connectTimeout: 100,
-					ackTimeout: 100,
+					connectTimeout: 1000,
+					ackTimeout: 1000,
 					// Set a different discoveryInterval for each node; that way they don't keep trying to discover each other at the same time.
 					discoveryInterval: DISCOVERY_INTERVAL + index * 11,
 					nodeInfo: {

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -94,8 +94,8 @@ describe('Integration tests for P2P library', () => {
 					seedPeers,
 					wsEngine: 'ws',
 					// A short connectTimeout and ackTimeout will make the node to give up on discovery quicker for our test.
-					connectTimeout: 100,
-					ackTimeout: 100,
+					connectTimeout: 1000,
+					ackTimeout: 1000,
 					// Set a different discoveryInterval for each node; that way they don't keep trying to discover each other at the same time.
 					discoveryInterval: DISCOVERY_INTERVAL + index * 11,
 					nodeInfo: {


### PR DESCRIPTION
### What was the problem?

Integration tests are failing randomly in p2p.

### How did I fix it?

For partial network test, the value of `ackTimeout` and `connectTimeout` was very low (100ms) and sometimes it was not enough time to connect with other nodes if the network is a bit slow. We have increased the timeouts to 1000ms.

### How to test it?

`npm t`

### Review checklist

* The PR resolves #1103 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
