### PR TITLE
Fix validation of asset data - Closes #1214

### DIFF
--- a/packages/lisk-transactions/package-lock.json
+++ b/packages/lisk-transactions/package-lock.json
@@ -186,6 +186,28 @@
 				}
 			}
 		},
+		"@liskhq/lisk-cryptography": {
+			"version": "2.1.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/@liskhq/lisk-cryptography/-/lisk-cryptography-2.1.0-alpha.0.tgz",
+			"integrity": "sha512-mxrNmAlvc8K6un/ZGySQUJ+R/PeNAHH7jUT24kGkGUoZqDGnJQJ8Km4OI97xZknQ37TWKM+yMo4X/vYKNmljHQ==",
+			"requires": {
+				"@types/ed2curve": "0.2.2",
+				"@types/node": "10.12.21",
+				"browserify-bignum": "1.3.0-2",
+				"buffer-reverse": "1.0.1",
+				"ed2curve": "0.2.1",
+				"sodium-native": "2.2.1",
+				"tweetnacl": "1.0.1",
+				"varuint-bitcoin": "1.1.0"
+			},
+			"dependencies": {
+				"tweetnacl": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
+					"integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
+				}
+			}
+		},
 		"@sinonjs/commons": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
@@ -248,6 +270,21 @@
 			"requires": {
 				"@types/chai": "*",
 				"@types/jquery": "*"
+			}
+		},
+		"@types/ed2curve": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/@types/ed2curve/-/ed2curve-0.2.2.tgz",
+			"integrity": "sha512-G1sTX5xo91ydevQPINbL2nfgVAj/s1ZiqZxC8OCWduwu+edoNGUm5JXtTkg9F3LsBZbRI46/0HES4CPUE2wc9g==",
+			"requires": {
+				"tweetnacl": "^1.0.0"
+			},
+			"dependencies": {
+				"tweetnacl": {
+					"version": "1.0.1",
+					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
+					"integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
+				}
 			}
 		},
 		"@types/expect": {
@@ -735,6 +772,11 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
+		"browserify-bignum": {
+			"version": "1.3.0-2",
+			"resolved": "https://registry.npmjs.org/browserify-bignum/-/browserify-bignum-1.3.0-2.tgz",
+			"integrity": "sha1-3cO27WB/1slglmlQ4rNaKwxvub8="
+		},
 		"browserify-cipher": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
@@ -813,6 +855,11 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
+		},
+		"buffer-reverse": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
+			"integrity": "sha1-SSg8jvpvkBvAH6MwTQYCeXGuL2A="
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
@@ -1382,6 +1429,14 @@
 				"url-join": "^2.0.5"
 			}
 		},
+		"ed2curve": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.2.1.tgz",
+			"integrity": "sha1-Iuaqo1aePE2/Tu+ilhLsMp5YGQw=",
+			"requires": {
+				"tweetnacl": "0.x.x"
+			}
+		},
 		"elegant-spinner": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
@@ -1915,8 +1970,7 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inline-source-map": {
 			"version": "0.6.2",
@@ -2588,6 +2642,12 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
 		},
+		"nan": {
+			"version": "2.13.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+			"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+			"optional": true
+		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -2614,6 +2674,12 @@
 					"dev": true
 				}
 			}
+		},
+		"node-gyp-build": {
+			"version": "3.8.0",
+			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.8.0.tgz",
+			"integrity": "sha512-bYbpIHyRqZ7sVWXxGpz8QIRug5JZc/hzZH4GbdT9HTZi6WmKCZ8GLvP8OZ9TTiIBvwPFKgtGrlWQSXDAvYdsPw==",
+			"optional": true
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
@@ -4151,8 +4217,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -4262,6 +4327,17 @@
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
 			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
 			"dev": true
+		},
+		"sodium-native": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.2.1.tgz",
+			"integrity": "sha512-3CfftYV2ATXQFMIkLOvcNUk/Ma+lran0855j5Z/HEjUkSTzjLZi16CK362udOoNVrwn/TwGV8bKEt5OylsFrQA==",
+			"optional": true,
+			"requires": {
+				"ini": "^1.3.5",
+				"nan": "^2.4.0",
+				"node-gyp-build": "^3.0.0"
+			}
 		},
 		"source-map": {
 			"version": "0.5.7",
@@ -4635,8 +4711,7 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type-detect": {
 			"version": "4.0.8",
@@ -4774,6 +4849,14 @@
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 			"dev": true
+		},
+		"varuint-bitcoin": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
+			"integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
+			"requires": {
+				"safe-buffer": "^5.1.1"
+			}
 		},
 		"verror": {
 			"version": "1.10.0",

--- a/packages/lisk-transactions/package-lock.json
+++ b/packages/lisk-transactions/package-lock.json
@@ -186,28 +186,6 @@
 				}
 			}
 		},
-		"@liskhq/lisk-cryptography": {
-			"version": "2.1.0-alpha.0",
-			"resolved": "https://registry.npmjs.org/@liskhq/lisk-cryptography/-/lisk-cryptography-2.1.0-alpha.0.tgz",
-			"integrity": "sha512-mxrNmAlvc8K6un/ZGySQUJ+R/PeNAHH7jUT24kGkGUoZqDGnJQJ8Km4OI97xZknQ37TWKM+yMo4X/vYKNmljHQ==",
-			"requires": {
-				"@types/ed2curve": "0.2.2",
-				"@types/node": "10.12.21",
-				"browserify-bignum": "1.3.0-2",
-				"buffer-reverse": "1.0.1",
-				"ed2curve": "0.2.1",
-				"sodium-native": "2.2.1",
-				"tweetnacl": "1.0.1",
-				"varuint-bitcoin": "1.1.0"
-			},
-			"dependencies": {
-				"tweetnacl": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-					"integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-				}
-			}
-		},
 		"@sinonjs/commons": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
@@ -270,21 +248,6 @@
 			"requires": {
 				"@types/chai": "*",
 				"@types/jquery": "*"
-			}
-		},
-		"@types/ed2curve": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/@types/ed2curve/-/ed2curve-0.2.2.tgz",
-			"integrity": "sha512-G1sTX5xo91ydevQPINbL2nfgVAj/s1ZiqZxC8OCWduwu+edoNGUm5JXtTkg9F3LsBZbRI46/0HES4CPUE2wc9g==",
-			"requires": {
-				"tweetnacl": "^1.0.0"
-			},
-			"dependencies": {
-				"tweetnacl": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.1.tgz",
-					"integrity": "sha512-kcoMoKTPYnoeS50tzoqjPY3Uv9axeuuFAZY9M/9zFnhoVvRfxz9K29IMPD7jGmt2c8SW7i3gT9WqDl2+nV7p4A=="
-				}
 			}
 		},
 		"@types/expect": {
@@ -772,11 +735,6 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"browserify-bignum": {
-			"version": "1.3.0-2",
-			"resolved": "https://registry.npmjs.org/browserify-bignum/-/browserify-bignum-1.3.0-2.tgz",
-			"integrity": "sha1-3cO27WB/1slglmlQ4rNaKwxvub8="
-		},
 		"browserify-cipher": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
@@ -855,11 +813,6 @@
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
 			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
 			"dev": true
-		},
-		"buffer-reverse": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
-			"integrity": "sha1-SSg8jvpvkBvAH6MwTQYCeXGuL2A="
 		},
 		"buffer-xor": {
 			"version": "1.0.3",
@@ -1429,14 +1382,6 @@
 				"url-join": "^2.0.5"
 			}
 		},
-		"ed2curve": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/ed2curve/-/ed2curve-0.2.1.tgz",
-			"integrity": "sha1-Iuaqo1aePE2/Tu+ilhLsMp5YGQw=",
-			"requires": {
-				"tweetnacl": "0.x.x"
-			}
-		},
 		"elegant-spinner": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
@@ -1970,7 +1915,8 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"dev": true
 		},
 		"inline-source-map": {
 			"version": "0.6.2",
@@ -2642,12 +2588,6 @@
 			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
 			"dev": true
 		},
-		"nan": {
-			"version": "2.13.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-			"integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
-			"optional": true
-		},
 		"nice-try": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -2674,12 +2614,6 @@
 					"dev": true
 				}
 			}
-		},
-		"node-gyp-build": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-3.8.0.tgz",
-			"integrity": "sha512-bYbpIHyRqZ7sVWXxGpz8QIRug5JZc/hzZH4GbdT9HTZi6WmKCZ8GLvP8OZ9TTiIBvwPFKgtGrlWQSXDAvYdsPw==",
-			"optional": true
 		},
 		"npm-run-path": {
 			"version": "2.0.2",
@@ -4217,7 +4151,8 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -4327,17 +4262,6 @@
 			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
 			"integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
 			"dev": true
-		},
-		"sodium-native": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-2.2.1.tgz",
-			"integrity": "sha512-3CfftYV2ATXQFMIkLOvcNUk/Ma+lran0855j5Z/HEjUkSTzjLZi16CK362udOoNVrwn/TwGV8bKEt5OylsFrQA==",
-			"optional": true,
-			"requires": {
-				"ini": "^1.3.5",
-				"nan": "^2.4.0",
-				"node-gyp-build": "^3.0.0"
-			}
 		},
 		"source-map": {
 			"version": "0.5.7",
@@ -4711,7 +4635,8 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true
 		},
 		"type-detect": {
 			"version": "4.0.8",
@@ -4849,14 +4774,6 @@
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 			"dev": true
-		},
-		"varuint-bitcoin": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/varuint-bitcoin/-/varuint-bitcoin-1.1.0.tgz",
-			"integrity": "sha512-jCEPG+COU/1Rp84neKTyDJQr478/hAfVp5xxYn09QEH0yBjbmPeMfuuQIrp+BUD83hybtYZKhr5elV3bvdV1bA==",
-			"requires": {
-				"safe-buffer": "^5.1.1"
-			}
 		},
 		"verror": {
 			"version": "1.10.0",

--- a/packages/lisk-transactions/src/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/0_transfer_transaction.ts
@@ -20,7 +20,7 @@ import {
 	StateStorePrepare,
 } from './base_transaction';
 import { MAX_TRANSACTION_AMOUNT, TRANSFER_FEE } from './constants';
-import { TransactionError } from './errors';
+import { convertToAssetError, TransactionError } from './errors';
 import { TransactionJSON } from './transaction_types';
 import {
 	validateAddress,
@@ -91,16 +91,10 @@ export class TransferTransaction extends BaseTransaction {
 
 	protected validateAsset(): ReadonlyArray<TransactionError> {
 		validator.validate(transferAssetFormatSchema, this.asset);
-		const errors = validator.errors
-			? validator.errors.map(
-					error =>
-						new TransactionError(
-							`'${error.dataPath}' ${error.message}`,
-							this.id,
-							error.dataPath,
-						),
-			  )
-			: [];
+		const errors = convertToAssetError(
+			this.id,
+			validator.errors,
+		) as TransactionError[];
 
 		if (this.type !== TRANSACTION_TRANSFER_TYPE) {
 			errors.push(

--- a/packages/lisk-transactions/src/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/0_transfer_transaction.ts
@@ -62,7 +62,7 @@ export class TransferTransaction extends BaseTransaction {
 	protected assetToBytes(): Buffer {
 		const { data } = this.asset;
 
-		return data ? Buffer.from(data, 'utf8') : Buffer.alloc(0);
+		return typeof data === 'string' ? Buffer.from(data, 'utf8') : Buffer.alloc(0);
 	}
 
 	public assetToJSON(): TransferAsset {

--- a/packages/lisk-transactions/src/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/0_transfer_transaction.ts
@@ -66,9 +66,7 @@ export class TransferTransaction extends BaseTransaction {
 	}
 
 	public assetToJSON(): TransferAsset {
-		return {
-			...this.asset,
-		};
+		return this.asset;
 	}
 
 	public async prepare(store: StateStorePrepare): Promise<void> {

--- a/packages/lisk-transactions/src/0_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/0_transfer_transaction.ts
@@ -62,7 +62,7 @@ export class TransferTransaction extends BaseTransaction {
 	protected assetToBytes(): Buffer {
 		const { data } = this.asset;
 
-		return typeof data === 'string' ? Buffer.from(data, 'utf8') : Buffer.alloc(0);
+		return data ? Buffer.from(data, 'utf8') : Buffer.alloc(0);
 	}
 
 	public assetToJSON(): TransferAsset {

--- a/packages/lisk-transactions/src/1_second_signature_transaction.ts
+++ b/packages/lisk-transactions/src/1_second_signature_transaction.ts
@@ -64,7 +64,7 @@ export class SecondSignatureTransaction extends BaseTransaction {
 			signature: { publicKey },
 		} = this.asset;
 
-		return hexToBuffer(publicKey);
+		return typeof publicKey === 'string' ? hexToBuffer(publicKey) : Buffer.alloc(0);
 	}
 
 	public assetToJSON(): object {

--- a/packages/lisk-transactions/src/1_second_signature_transaction.ts
+++ b/packages/lisk-transactions/src/1_second_signature_transaction.ts
@@ -19,7 +19,7 @@ import {
 	StateStorePrepare,
 } from './base_transaction';
 import { SIGNATURE_FEE } from './constants';
-import { convertToTransactionError, TransactionError } from './errors';
+import { convertToAssetError, TransactionError } from './errors';
 import { TransactionJSON } from './transaction_types';
 import { getId, validator } from './utils';
 
@@ -101,7 +101,7 @@ export class SecondSignatureTransaction extends BaseTransaction {
 
 	protected validateAsset(): ReadonlyArray<TransactionError> {
 		validator.validate(secondSignatureAssetFormatSchema, this.asset);
-		const errors = convertToTransactionError(
+		const errors = convertToAssetError(
 			this.id,
 			validator.errors,
 		) as TransactionError[];

--- a/packages/lisk-transactions/src/1_second_signature_transaction.ts
+++ b/packages/lisk-transactions/src/1_second_signature_transaction.ts
@@ -64,7 +64,7 @@ export class SecondSignatureTransaction extends BaseTransaction {
 			signature: { publicKey },
 		} = this.asset;
 
-		return typeof publicKey === 'string' ? hexToBuffer(publicKey) : Buffer.alloc(0);
+		return hexToBuffer(publicKey);
 	}
 
 	public assetToJSON(): object {

--- a/packages/lisk-transactions/src/1_second_signature_transaction.ts
+++ b/packages/lisk-transactions/src/1_second_signature_transaction.ts
@@ -68,9 +68,7 @@ export class SecondSignatureTransaction extends BaseTransaction {
 	}
 
 	public assetToJSON(): object {
-		return {
-			...this.asset,
-		};
+		return this.asset;
 	}
 
 	public async prepare(store: StateStorePrepare): Promise<void> {

--- a/packages/lisk-transactions/src/2_delegate_transaction.ts
+++ b/packages/lisk-transactions/src/2_delegate_transaction.ts
@@ -71,9 +71,7 @@ export class DelegateTransaction extends BaseTransaction {
 	}
 
 	public assetToJSON(): DelegateAsset {
-		return {
-			...this.asset,
-		};
+		return this.asset;
 	}
 
 	public async prepare(store: StateStorePrepare): Promise<void> {

--- a/packages/lisk-transactions/src/2_delegate_transaction.ts
+++ b/packages/lisk-transactions/src/2_delegate_transaction.ts
@@ -18,7 +18,7 @@ import {
 	StateStorePrepare,
 } from './base_transaction';
 import { DELEGATE_FEE } from './constants';
-import { convertToTransactionError, TransactionError } from './errors';
+import { convertToAssetError, TransactionError } from './errors';
 import { Account, TransactionJSON } from './transaction_types';
 import { validator } from './utils';
 
@@ -107,7 +107,7 @@ export class DelegateTransaction extends BaseTransaction {
 
 	protected validateAsset(): ReadonlyArray<TransactionError> {
 		validator.validate(delegateAssetFormatSchema, this.asset);
-		const errors = convertToTransactionError(
+		const errors = convertToAssetError(
 			this.id,
 			validator.errors,
 		) as TransactionError[];

--- a/packages/lisk-transactions/src/2_delegate_transaction.ts
+++ b/packages/lisk-transactions/src/2_delegate_transaction.ts
@@ -67,7 +67,7 @@ export class DelegateTransaction extends BaseTransaction {
 			delegate: { username },
 		} = this.asset;
 
-		return Buffer.from(username, 'utf8');
+		return typeof username === 'string' ? Buffer.from(username, 'utf8') : Buffer.alloc(0);
 	}
 
 	public assetToJSON(): DelegateAsset {

--- a/packages/lisk-transactions/src/2_delegate_transaction.ts
+++ b/packages/lisk-transactions/src/2_delegate_transaction.ts
@@ -67,7 +67,7 @@ export class DelegateTransaction extends BaseTransaction {
 			delegate: { username },
 		} = this.asset;
 
-		return typeof username === 'string' ? Buffer.from(username, 'utf8') : Buffer.alloc(0);
+		return Buffer.from(username, 'utf8');
 	}
 
 	public assetToJSON(): DelegateAsset {

--- a/packages/lisk-transactions/src/3_vote_transaction.ts
+++ b/packages/lisk-transactions/src/3_vote_transaction.ts
@@ -49,13 +49,13 @@ export const voteAssetFormatSchema = {
 	properties: {
 		votes: {
 			type: 'array',
-			uniqueSignedPublicKeys: true,
 			minItems: MIN_VOTE_PER_TX,
 			maxItems: MAX_VOTE_PER_TX,
 			items: {
 				type: 'string',
 				format: 'signedPublicKey',
 			},
+			uniqueSignedPublicKeys: true,
 		},
 	},
 };

--- a/packages/lisk-transactions/src/3_vote_transaction.ts
+++ b/packages/lisk-transactions/src/3_vote_transaction.ts
@@ -74,7 +74,10 @@ export class VoteTransaction extends BaseTransaction {
 	}
 
 	protected assetToBytes(): Buffer {
-		return Buffer.from(this.asset.votes.join(''), 'utf8');
+		return Array.isArray(this.asset.votes) &&
+			this.asset.votes.every(vote => typeof vote === 'string')
+			? Buffer.from(this.asset.votes.join(''), 'utf8')
+			: Buffer.alloc(0);
 	}
 
 	public assetToJSON(): object {

--- a/packages/lisk-transactions/src/3_vote_transaction.ts
+++ b/packages/lisk-transactions/src/3_vote_transaction.ts
@@ -74,10 +74,7 @@ export class VoteTransaction extends BaseTransaction {
 	}
 
 	protected assetToBytes(): Buffer {
-		return Array.isArray(this.asset.votes) &&
-			this.asset.votes.every(vote => typeof vote === 'string')
-			? Buffer.from(this.asset.votes.join(''), 'utf8')
-			: Buffer.alloc(0);
+		return Buffer.from(this.asset.votes.join(''), 'utf8');
 	}
 
 	public assetToJSON(): object {

--- a/packages/lisk-transactions/src/3_vote_transaction.ts
+++ b/packages/lisk-transactions/src/3_vote_transaction.ts
@@ -20,7 +20,7 @@ import {
 	StateStorePrepare,
 } from './base_transaction';
 import { MAX_TRANSACTION_AMOUNT, VOTE_FEE } from './constants';
-import { convertToTransactionError, TransactionError } from './errors';
+import { convertToAssetError, TransactionError } from './errors';
 import { TransactionJSON } from './transaction_types';
 import { CreateBaseTransactionInput, verifyAmountBalance } from './utils';
 import { validateAddress, validator } from './utils/validation';
@@ -137,10 +137,11 @@ export class VoteTransaction extends BaseTransaction {
 
 	protected validateAsset(): ReadonlyArray<TransactionError> {
 		validator.validate(voteAssetFormatSchema, this.asset);
-		const errors = convertToTransactionError(
+		const errors = convertToAssetError(
 			this.id,
 			validator.errors,
 		) as TransactionError[];
+
 		if (!this.amount.eq(0)) {
 			errors.push(
 				new TransactionError(

--- a/packages/lisk-transactions/src/3_vote_transaction.ts
+++ b/packages/lisk-transactions/src/3_vote_transaction.ts
@@ -78,9 +78,7 @@ export class VoteTransaction extends BaseTransaction {
 	}
 
 	public assetToJSON(): object {
-		return {
-			votes: this.asset.votes,
-		};
+		return this.asset;
 	}
 
 	public async prepare(store: StateStorePrepare): Promise<void> {

--- a/packages/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/src/4_multisignature_transaction.ts
@@ -164,6 +164,11 @@ export class MultisignatureTransaction extends BaseTransaction {
 				),
 			);
 		}
+
+		if (errors.length > 0) {
+			return errors;
+		}
+
 		const expectedFee = new BigNum(MULTISIGNATURE_FEE).mul(
 			this.asset.multisignature.keysgroup.length + 1,
 		);

--- a/packages/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/src/4_multisignature_transaction.ts
@@ -89,9 +89,17 @@ export class MultisignatureTransaction extends BaseTransaction {
 		const {
 			multisignature: { min, lifetime, keysgroup },
 		} = this.asset;
-		const minBuffer = Buffer.alloc(1, min);
-		const lifetimeBuffer = Buffer.alloc(1, lifetime);
-		const keysgroupBuffer = Buffer.from(keysgroup.join(''), 'utf8');
+		const minBuffer =
+			typeof min === 'number' ? Buffer.alloc(1, min) : Buffer.alloc(0);
+		const lifetimeBuffer =
+			typeof lifetime === 'number'
+				? Buffer.alloc(1, lifetime)
+				: Buffer.alloc(0);
+		const keysgroupBuffer =
+			Array.isArray(keysgroup) &&
+			keysgroup.every(key => typeof key === 'string')
+				? Buffer.from(keysgroup.join(''), 'utf8')
+				: Buffer.alloc(0);
 
 		return Buffer.concat([minBuffer, lifetimeBuffer, keysgroupBuffer]);
 	}

--- a/packages/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/src/4_multisignature_transaction.ts
@@ -89,17 +89,9 @@ export class MultisignatureTransaction extends BaseTransaction {
 		const {
 			multisignature: { min, lifetime, keysgroup },
 		} = this.asset;
-		const minBuffer =
-			typeof min === 'number' ? Buffer.alloc(1, min) : Buffer.alloc(0);
-		const lifetimeBuffer =
-			typeof lifetime === 'number'
-				? Buffer.alloc(1, lifetime)
-				: Buffer.alloc(0);
-		const keysgroupBuffer =
-			Array.isArray(keysgroup) &&
-			keysgroup.every(key => typeof key === 'string')
-				? Buffer.from(keysgroup.join(''), 'utf8')
-				: Buffer.alloc(0);
+		const minBuffer = Buffer.alloc(1, min);
+		const lifetimeBuffer = Buffer.alloc(1, lifetime);
+		const keysgroupBuffer = Buffer.from(keysgroup.join(''), 'utf8');
 
 		return Buffer.concat([minBuffer, lifetimeBuffer, keysgroupBuffer]);
 	}

--- a/packages/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/src/4_multisignature_transaction.ts
@@ -22,7 +22,7 @@ import {
 import { MULTISIGNATURE_FEE } from './constants';
 import { SignatureObject } from './create_signature_object';
 import {
-	convertToTransactionError,
+	convertToAssetError,
 	TransactionError,
 	TransactionPendingError,
 } from './errors';
@@ -136,7 +136,7 @@ export class MultisignatureTransaction extends BaseTransaction {
 
 	protected validateAsset(): ReadonlyArray<TransactionError> {
 		validator.validate(multisignatureAssetFormatSchema, this.asset);
-		const errors = convertToTransactionError(
+		const errors = convertToAssetError(
 			this.id,
 			validator.errors,
 		) as TransactionError[];

--- a/packages/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/src/4_multisignature_transaction.ts
@@ -97,13 +97,7 @@ export class MultisignatureTransaction extends BaseTransaction {
 	}
 
 	public assetToJSON(): MultiSignatureAsset {
-		return {
-			multisignature: {
-				min: this.asset.multisignature.min,
-				lifetime: this.asset.multisignature.lifetime,
-				keysgroup: [...this.asset.multisignature.keysgroup],
-			},
-		};
+		return this.asset;
 	}
 
 	public async prepare(store: StateStorePrepare): Promise<void> {

--- a/packages/lisk-transactions/src/5_dapp_transaction.ts
+++ b/packages/lisk-transactions/src/5_dapp_transaction.ts
@@ -145,9 +145,7 @@ export class DappTransaction extends BaseTransaction {
 	}
 
 	public assetToJSON(): object {
-		return {
-			...this.asset,
-		};
+		return this.asset;
 	}
 
 	public async prepare(store: StateStorePrepare): Promise<void> {

--- a/packages/lisk-transactions/src/5_dapp_transaction.ts
+++ b/packages/lisk-transactions/src/5_dapp_transaction.ts
@@ -98,13 +98,14 @@ export class DappTransaction extends BaseTransaction {
 		const tx = (typeof rawTransaction === 'object' && rawTransaction !== null
 			? rawTransaction
 			: {}) as Partial<TransactionJSON>;
-
 		this.asset = (tx.asset || { dapp: {} }) as DappAsset;
-		// If Optional field contains null, converts to undefined
-		this.asset.dapp.description = this.asset.dapp.description || undefined;
-		this.asset.dapp.icon = this.asset.dapp.icon || undefined;
-		this.asset.dapp.tags = this.asset.dapp.tags || undefined;
 		this.containsUniqueData = true;
+		if (this.asset && this.asset.dapp && typeof this.asset.dapp === 'object') {
+			// If Optional field contains null, converts to undefined
+			this.asset.dapp.description = this.asset.dapp.description || undefined;
+			this.asset.dapp.icon = this.asset.dapp.icon || undefined;
+			this.asset.dapp.tags = this.asset.dapp.tags || undefined;
+		}
 	}
 
 	protected assetToBytes(): Buffer {
@@ -260,6 +261,11 @@ export class DappTransaction extends BaseTransaction {
 			);
 		}
 		const validLinkSuffix = ['.zip'];
+
+		if (errors.length > 0) {
+			return errors;
+		}
+
 		if (
 			this.asset.dapp.link &&
 			!stringEndsWith(this.asset.dapp.link, validLinkSuffix)

--- a/packages/lisk-transactions/src/5_dapp_transaction.ts
+++ b/packages/lisk-transactions/src/5_dapp_transaction.ts
@@ -18,7 +18,7 @@ import {
 	StateStorePrepare,
 } from './base_transaction';
 import { DAPP_FEE } from './constants';
-import { convertToTransactionError, TransactionError } from './errors';
+import { convertToAssetError, TransactionError } from './errors';
 import { TransactionJSON } from './transaction_types';
 import { stringEndsWith, validator } from './utils/validation';
 
@@ -209,7 +209,7 @@ export class DappTransaction extends BaseTransaction {
 
 	protected validateAsset(): ReadonlyArray<TransactionError> {
 		validator.validate(dappAssetFormatSchema, this.asset);
-		const errors = convertToTransactionError(
+		const errors = convertToAssetError(
 			this.id,
 			validator.errors,
 		) as TransactionError[];

--- a/packages/lisk-transactions/src/6_in_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/6_in_transfer_transaction.ts
@@ -90,9 +90,7 @@ export class InTransferTransaction extends BaseTransaction {
 	}
 
 	public assetToJSON(): object {
-		return {
-			...this.asset,
-		};
+		return this.asset;
 	}
 
 	// tslint:disable-next-line prefer-function-over-method

--- a/packages/lisk-transactions/src/6_in_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/6_in_transfer_transaction.ts
@@ -19,7 +19,7 @@ import {
 	StateStorePrepare,
 } from './base_transaction';
 import { IN_TRANSFER_FEE } from './constants';
-import { convertToTransactionError, TransactionError } from './errors';
+import { convertToAssetError, TransactionError } from './errors';
 import { TransactionJSON } from './transaction_types';
 import { convertBeddowsToLSK, verifyAmountBalance } from './utils';
 import { validator } from './utils/validation';
@@ -104,7 +104,7 @@ export class InTransferTransaction extends BaseTransaction {
 
 	protected validateAsset(): ReadonlyArray<TransactionError> {
 		validator.validate(inTransferAssetFormatSchema, this.asset);
-		const errors = convertToTransactionError(
+		const errors = convertToAssetError(
 			this.id,
 			validator.errors,
 		) as TransactionError[];

--- a/packages/lisk-transactions/src/7_out_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/7_out_transfer_transaction.ts
@@ -93,9 +93,7 @@ export class OutTransferTransaction extends BaseTransaction {
 	}
 
 	public assetToJSON(): object {
-		return {
-			...this.asset,
-		};
+		return this.asset;
 	}
 
 	protected verifyAgainstTransactions(

--- a/packages/lisk-transactions/src/7_out_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/7_out_transfer_transaction.ts
@@ -19,7 +19,7 @@ import {
 	StateStorePrepare,
 } from './base_transaction';
 import { MAX_TRANSACTION_AMOUNT, OUT_TRANSFER_FEE } from './constants';
-import { convertToTransactionError, TransactionError } from './errors';
+import { convertToAssetError, TransactionError } from './errors';
 import { TransactionJSON } from './transaction_types';
 import { verifyAmountBalance } from './utils';
 import { validator } from './utils/validation';
@@ -122,7 +122,7 @@ export class OutTransferTransaction extends BaseTransaction {
 
 	protected validateAsset(): ReadonlyArray<TransactionError> {
 		validator.validate(outTransferAssetFormatSchema, this.asset);
-		const errors = convertToTransactionError(
+		const errors = convertToAssetError(
 			this.id,
 			validator.errors,
 		) as TransactionError[];

--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -235,6 +235,10 @@ export abstract class BaseTransaction {
 	public validate(): TransactionResponse {
 		const errors = [...this._validateSchema(), ...this.validateAsset()];
 
+		if (errors.length > 0) {
+			return createResponse(this.id, errors);
+		}
+
 		const transactionBytes = this.getBasicBytes();
 
 		const {

--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -233,16 +233,11 @@ export abstract class BaseTransaction {
 	}
 
 	public validate(): TransactionResponse {
-		const validateAssetErrors = this.validateAsset();
-		if (validateAssetErrors.length > 0) {
-			return createResponse(this.id, validateAssetErrors);
-		}
-		const validateSchemaErrors = this._validateSchema();
-		if (validateSchemaErrors.length > 0) {
-			return createResponse(this.id, validateSchemaErrors);
+		const errors = [...this._validateSchema(), ...this.validateAsset()];
+		if (errors.length > 0) {
+			return createResponse(this.id, errors);
 		}
 		const transactionBytes = this.getBasicBytes();
-		const errors: TransactionError[] = [];
 
 		const {
 			valid: signatureValid,

--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -237,14 +237,11 @@ export abstract class BaseTransaction {
 		if (validateAssetErrors.length > 0) {
 			return createResponse(this.id, validateAssetErrors);
 		}
-
 		const validateSchemaErrors = this._validateSchema();
 		if (validateSchemaErrors.length > 0) {
 			return createResponse(this.id, validateSchemaErrors);
 		}
-
 		const transactionBytes = this.getBasicBytes();
-
 		const errors: TransactionError[] = [];
 
 		const {

--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -233,13 +233,19 @@ export abstract class BaseTransaction {
 	}
 
 	public validate(): TransactionResponse {
-		const errors = [...this._validateSchema(), ...this.validateAsset()];
+		const validateAssetErrors = this.validateAsset();
+		if (validateAssetErrors.length > 0) {
+			return createResponse(this.id, validateAssetErrors);
+		}
 
-		if (errors.length > 0) {
-			return createResponse(this.id, errors);
+		const validateSchemaErrors = this._validateSchema();
+		if (validateSchemaErrors.length > 0) {
+			return createResponse(this.id, validateSchemaErrors);
 		}
 
 		const transactionBytes = this.getBasicBytes();
+
+		const errors: TransactionError[] = [];
 
 		const {
 			valid: signatureValid,

--- a/packages/lisk-transactions/src/base_transaction.ts
+++ b/packages/lisk-transactions/src/base_transaction.ts
@@ -255,6 +255,12 @@ export abstract class BaseTransaction {
 			errors.push(verificationError);
 		}
 
+		const idError = validateTransactionId(this.id, this.getBytes());
+
+		if (idError) {
+			errors.push(idError);
+		}
+
 		return createResponse(this.id, errors);
 	}
 
@@ -521,10 +527,6 @@ export abstract class BaseTransaction {
 			if (senderIdError) {
 				errors.push(senderIdError);
 			}
-		}
-		const idError = validateTransactionId(this.id, this.getBytes());
-		if (idError) {
-			errors.push(idError);
 		}
 
 		return errors;

--- a/packages/lisk-transactions/src/errors.ts
+++ b/packages/lisk-transactions/src/errors.ts
@@ -87,9 +87,9 @@ export const convertToTransactionError = (
 	return errors.map(
 		error =>
 			new TransactionError(
-				`'${error.dataPath}' ${error.message}`,
+				`'${error.dataPath || '.asset'}' ${error.message}`,
 				id,
-				error.dataPath,
+				error.dataPath || '.asset',
 			),
 	);
 };

--- a/packages/lisk-transactions/src/errors.ts
+++ b/packages/lisk-transactions/src/errors.ts
@@ -87,6 +87,24 @@ export const convertToTransactionError = (
 	return errors.map(
 		error =>
 			new TransactionError(
+				`'${error.dataPath}' ${error.message}`,
+				id,
+				error.dataPath,
+			),
+	);
+};
+
+export const convertToAssetError = (
+	id: string,
+	errors: ReadonlyArray<ErrorObject> | null | undefined,
+): ReadonlyArray<TransactionError> => {
+	if (!errors) {
+		return [];
+	}
+
+	return errors.map(
+		error =>
+			new TransactionError(
 				`'${error.dataPath || '.asset'}' ${error.message}`,
 				id,
 				error.dataPath || '.asset',

--- a/packages/lisk-transactions/src/utils/validation/validator.ts
+++ b/packages/lisk-transactions/src/utils/validation/validator.ts
@@ -120,7 +120,11 @@ validator.addFormat('noNullByte', data => !isNullByteIncluded(data));
 validator.addKeyword('uniqueSignedPublicKeys', {
 	type: 'array',
 	compile: () => (data: ReadonlyArray<string>) =>
-		new Set(data.map((key: string) => key.slice(1))).size === data.length,
+		new Set(
+			data
+				.filter(datum => typeof datum === 'string')
+				.map((key: string) => key.slice(1)),
+		).size === data.length,
 });
 
 validator.addSchema(schemas.baseTransaction);

--- a/packages/lisk-transactions/test/3_vote_transaction.ts
+++ b/packages/lisk-transactions/test/3_vote_transaction.ts
@@ -254,6 +254,18 @@ describe('Vote transaction class', () => {
 			expect(errors).not.to.be.empty;
 		});
 
+		it('should return error when asset includes null', async () => {
+			const invalidTransaction = {
+				...validVoteTransactions[2],
+				asset: {
+					votes: [null],
+				},
+			};
+			const transaction = new VoteTransaction(invalidTransaction);
+			const errors = (transaction as any).validateAsset();
+			expect(errors).not.to.be.empty;
+		});
+
 		it('should return error when asset is an empty array', async () => {
 			const invalidTransaction = {
 				...validVoteTransactions[2],

--- a/packages/lisk-transactions/test/base_transaction.ts
+++ b/packages/lisk-transactions/test/base_transaction.ts
@@ -415,26 +415,6 @@ describe('Base transaction class', () => {
 			).to.have.been.calledWithExactly(validTestTransaction.senderPublicKey);
 		});
 
-		it('should call getBytes', async () => {
-			sandbox
-				.stub(validTestTransaction, 'getBytes')
-				.returns(
-					Buffer.from(
-						'0022dcb9040eb0a6d7b862dc35c856c02c47fde3b4f60f2f3571a888b9a8ca7540c6793243ef4d6324449e824f6319182b02000000',
-						'hex',
-					),
-				);
-			(validTestTransaction as any)._validateSchema();
-			expect(validTestTransaction.getBytes).to.be.calledOnce;
-		});
-
-		it('should call validateTransactionId', async () => {
-			sandbox.stub(utils, 'validateTransactionId');
-			(validTestTransaction as any)._validateSchema();
-
-			expect(utils.validateTransactionId).to.be.calledOnce;
-		});
-
 		it('should return a successful transaction response with a valid transaction', async () => {
 			const errors = (validTestTransaction as any)._validateSchema();
 			expect(errors).to.be.empty;
@@ -470,20 +450,6 @@ describe('Base transaction class', () => {
 				invalidSenderIdTransaction as any,
 			);
 			const errors = (invalidSenderIdTestTransaction as any)._validateSchema();
-
-			expect(errors).to.not.be.empty;
-		});
-
-		it('should return a failed transaction response with an invalid id', async () => {
-			const invalidIdTransaction = {
-				...defaultTransaction,
-				id: defaultTransaction.id.replace('1', '0'),
-			};
-
-			const invalidIdTestTransaction = new TestTransaction(
-				invalidIdTransaction as any,
-			);
-			const errors = (invalidIdTestTransaction as any)._validateSchema();
 
 			expect(errors).to.not.be.empty;
 		});


### PR DESCRIPTION
### What was the problem?

1. `assetToBytes` and `getBasicBytes` called after schema checks failed causing error.

2. `assetToJSON` was destructuring invalid assets in initialization stage, causing errors.

3. `.dataPath` in errors were missing when asset themselves were of invalid type

4. Validation process for dapp and vote transactions were throwing error 

### How did I fix it?

Early return if errors produced from schema and asset validation. 

`assetToJSON` now simply returns itself.

New function specifically for filling missing `.dataPath` in errors.

Fixed initialization and validation issues for dapp and vote transactions. 

### How to test it?

npm run rest

### Review checklist

* The PR resolves #1214 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
