### PR TITLE
Deduct amount from account for exception vote transactions  - Closes #1215

### DIFF
--- a/packages/lisk-transactions/src/3_vote_transaction.ts
+++ b/packages/lisk-transactions/src/3_vote_transaction.ts
@@ -12,16 +12,17 @@
  * Removal or modification of this copyright notice is prohibited.
  *
  */
+import * as BigNum from '@liskhq/bignum';
 import { getAddressFromPublicKey } from '@liskhq/lisk-cryptography';
 import {
 	BaseTransaction,
 	StateStore,
 	StateStorePrepare,
 } from './base_transaction';
-import { VOTE_FEE } from './constants';
+import { MAX_TRANSACTION_AMOUNT, VOTE_FEE } from './constants';
 import { convertToTransactionError, TransactionError } from './errors';
 import { TransactionJSON } from './transaction_types';
-import { CreateBaseTransactionInput } from './utils';
+import { CreateBaseTransactionInput, verifyAmountBalance } from './utils';
 import { validateAddress, validator } from './utils/validation';
 
 const PREFIX_UPVOTE = '+';
@@ -208,6 +209,18 @@ export class VoteTransaction extends BaseTransaction {
 	protected applyAsset(store: StateStore): ReadonlyArray<TransactionError> {
 		const errors: TransactionError[] = [];
 		const sender = store.account.get(this.senderId);
+
+		const balanceError = verifyAmountBalance(
+			this.id,
+			sender,
+			this.amount,
+			this.fee,
+		);
+		if (balanceError) {
+			errors.push(balanceError);
+		}
+		const updatedSenderBalance = new BigNum(sender.balance).sub(this.amount);
+
 		this.asset.votes.forEach(actionVotes => {
 			const vote = actionVotes.substring(1);
 			const voteAccount = store.account.find(
@@ -277,6 +290,7 @@ export class VoteTransaction extends BaseTransaction {
 		}
 		const updatedSender = {
 			...sender,
+			balance: updatedSenderBalance.toString(),
 			votedDelegatesPublicKeys,
 		};
 		store.account.set(updatedSender.address, updatedSender);
@@ -287,6 +301,19 @@ export class VoteTransaction extends BaseTransaction {
 	protected undoAsset(store: StateStore): ReadonlyArray<TransactionError> {
 		const errors = [];
 		const sender = store.account.get(this.senderId);
+		const updatedSenderBalance = new BigNum(sender.balance).add(this.amount);
+
+		if (updatedSenderBalance.gt(MAX_TRANSACTION_AMOUNT)) {
+			errors.push(
+				new TransactionError(
+					'Invalid amount',
+					this.id,
+					'.amount',
+					this.amount.toString(),
+				),
+			);
+		}
+
 		const upvotes = this.asset.votes
 			.filter(vote => vote.charAt(0) === PREFIX_UPVOTE)
 			.map(vote => vote.substring(1));
@@ -313,6 +340,7 @@ export class VoteTransaction extends BaseTransaction {
 		}
 		const updatedSender = {
 			...sender,
+			balance: updatedSenderBalance.toString(),
 			votedDelegatesPublicKeys,
 		};
 		store.account.set(updatedSender.address, updatedSender);

--- a/packages/lisk-transactions/src/3_vote_transaction.ts
+++ b/packages/lisk-transactions/src/3_vote_transaction.ts
@@ -210,6 +210,8 @@ export class VoteTransaction extends BaseTransaction {
 		const errors: TransactionError[] = [];
 		const sender = store.account.get(this.senderId);
 
+		// Deduct amount from sender in case of exceptions
+		// See issue: https://github.com/LiskHQ/lisk-elements/issues/1215
 		const balanceError = verifyAmountBalance(
 			this.id,
 			sender,
@@ -303,6 +305,8 @@ export class VoteTransaction extends BaseTransaction {
 		const sender = store.account.get(this.senderId);
 		const updatedSenderBalance = new BigNum(sender.balance).add(this.amount);
 
+		// Deduct amount from sender in case of exceptions
+		// See issue: https://github.com/LiskHQ/lisk-elements/issues/1215
 		if (updatedSenderBalance.gt(MAX_TRANSACTION_AMOUNT)) {
 			errors.push(
 				new TransactionError(


### PR DESCRIPTION
### What was the problem?

For `testnet` vote transaction exceptions, amount should be deducted from sender account. 

### How did I fix it?

Validate remains as is and will invalidate vote transactions with amount.
Apply will now deduct amount from sender account.
Exceptions will bypass validate phase in core. 

### How to test it?

npm run test

### Review checklist

* The PR resolves #1215 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
