### PR TITLE
OutTransfer transaction should not fail if transaction with id provided in property "transactionId" already exists in the database - Closes 1219

### DIFF
--- a/packages/lisk-transactions/src/7_out_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/7_out_transfer_transaction.ts
@@ -192,22 +192,6 @@ export class OutTransferTransaction extends BaseTransaction {
 			);
 		}
 
-		const transactionExists = store.transaction.find(
-			(transaction: TransactionJSON) =>
-				transaction.id === this.asset.outTransfer.transactionId,
-		);
-
-		if (transactionExists) {
-			errors.push(
-				new TransactionError(
-					`Transaction ${
-						this.asset.outTransfer.transactionId
-					} is already processed.`,
-					this.id,
-				),
-			);
-		}
-
 		const sender = store.account.get(this.senderId);
 
 		const balanceError = verifyAmountBalance(

--- a/packages/lisk-transactions/test/7_out_transfer_transaction.ts
+++ b/packages/lisk-transactions/test/7_out_transfer_transaction.ts
@@ -36,7 +36,6 @@ describe('outTransfer transaction class', () => {
 	let validTestTransaction: OutTransferTransaction;
 	let storeTransactionCacheStub: sinon.SinonStub;
 	let storeTransactionGetStub: sinon.SinonStub;
-	let storeTransactionFindStub: sinon.SinonStub;
 	let storeAccountCacheStub: sinon.SinonStub;
 	let storeAccountGetStub: sinon.SinonStub;
 	let storeAccountSetStub: sinon.SinonStub;
@@ -47,7 +46,6 @@ describe('outTransfer transaction class', () => {
 		storeTransactionGetStub = sandbox
 			.stub(store.transaction, 'get')
 			.returns(dappRegistrationTx);
-		storeTransactionFindStub = sandbox.stub(store.transaction, 'find');
 		storeAccountCacheStub = sandbox.stub(store.account, 'cache');
 		storeAccountGetStub = sandbox
 			.stub(store.account, 'get')
@@ -252,7 +250,6 @@ describe('outTransfer transaction class', () => {
 			expect(storeTransactionGetStub).to.be.calledWithExactly(
 				validTestTransaction.asset.outTransfer.dappId,
 			);
-			expect(storeTransactionFindStub).to.be.calledOnce;
 			expect(
 				storeAccountGetStub
 					.getCall(0)
@@ -283,16 +280,6 @@ describe('outTransfer transaction class', () => {
 			const errors = (invalidTestTransaction as any).applyAsset(store);
 			expect(errors[0].message).to.equal(
 				`Out transaction must be sent from owner of the Dapp.`,
-			);
-		});
-
-		it('should return error if out transfer exists', async () => {
-			storeTransactionFindStub.returns(defaultTransaction);
-			const errors = (validTestTransaction as any).applyAsset(store);
-			expect(errors[0].message).to.equal(
-				`Transaction ${
-					validTestTransaction.asset.outTransfer.transactionId
-				} is already processed.`,
 			);
 		});
 


### PR DESCRIPTION
### What was the problem?
The OutTransfer transaction failed when asset.outTransfer.transactionId provided already existed in the database
### How did I fix it?
Removed the verification of transaction id provided in the asset field.
### How to test it?
Run the tests
### Review checklist

* The PR resolves #1219
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
