### PR TITLE
Recipient account should be created in case it does not exist for OutTransfer transaction

### DIFF
--- a/packages/lisk-transactions/src/7_out_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/7_out_transfer_transaction.ts
@@ -225,7 +225,7 @@ export class OutTransferTransaction extends BaseTransaction {
 		const updatedSender = { ...sender, balance: updatedBalance.toString() };
 		store.account.set(updatedSender.address, updatedSender);
 
-		const recipient = store.account.get(this.recipientId);
+		const recipient = store.account.getOrDefault(this.recipientId);
 
 		const updatedRecipientBalance = new BigNum(recipient.balance).add(
 			this.amount,
@@ -264,7 +264,7 @@ export class OutTransferTransaction extends BaseTransaction {
 		const updatedSender = { ...sender, balance: updatedBalance.toString() };
 		store.account.set(updatedSender.address, updatedSender);
 
-		const recipient = store.account.get(this.recipientId);
+		const recipient = store.account.getOrDefault(this.recipientId);
 
 		const updatedRecipientBalance = new BigNum(recipient.balance).sub(
 			this.amount,

--- a/packages/lisk-transactions/test/7_out_transfer_transaction.ts
+++ b/packages/lisk-transactions/test/7_out_transfer_transaction.ts
@@ -31,6 +31,12 @@ describe('outTransfer transaction class', () => {
 		publicKey:
 			'305b4897abc230c1cc9d0aa3bf0c75747bfa42f32f83f5a92348edea528850ad',
 	};
+	const defaultValidRecipient = {
+		address: '13155556493249255133L',
+		balance: '4700483466477',
+		publicKey:
+			'305b4897abc230c1cc9d0aa3bf0c75747bfa42f32f83f5a92348edea528850ad',
+	};
 	const dappRegistrationTx = validDappTransactions[3];
 
 	let validTestTransaction: OutTransferTransaction;
@@ -39,6 +45,7 @@ describe('outTransfer transaction class', () => {
 	let storeTransactionFindStub: sinon.SinonStub;
 	let storeAccountCacheStub: sinon.SinonStub;
 	let storeAccountGetStub: sinon.SinonStub;
+	let storeAccountGetOrDefaultStub: sinon.SinonStub;
 	let storeAccountSetStub: sinon.SinonStub;
 
 	beforeEach(async () => {
@@ -52,6 +59,9 @@ describe('outTransfer transaction class', () => {
 		storeAccountGetStub = sandbox
 			.stub(store.account, 'get')
 			.returns(defaultValidSender);
+		storeAccountGetOrDefaultStub = sandbox
+			.stub(store.account, 'getOrDefault')
+			.returns(defaultValidRecipient);
 		storeAccountSetStub = sandbox.stub(store.account, 'set');
 	});
 
@@ -269,8 +279,8 @@ describe('outTransfer transaction class', () => {
 					}),
 			);
 			expect(
-				storeAccountGetStub
-					.getCall(1)
+				storeAccountGetOrDefaultStub
+					.getCall(0)
 					.calledWithExactly(validTestTransaction.recipientId),
 			);
 		});
@@ -319,8 +329,8 @@ describe('outTransfer transaction class', () => {
 					.calledWithExactly(validTestTransaction.senderId),
 			);
 			expect(
-				storeAccountGetStub
-					.getCall(1)
+				storeAccountGetOrDefaultStub
+					.getCall(0)
 					.calledWithExactly(validTestTransaction.recipientId),
 			);
 		});


### PR DESCRIPTION
### What was the problem?
OutTransfer transaction did not create a default account for recipient in case it did not exist.
### How did I fix it?
Created default account for recipient account in case it did not exist.
### How to test it?
Run the tests.
### Review checklist

* The PR resolves #1220
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
