### PR TITLE
Fix the invalid filter for fetching dapp account in InTransfer Transaction

### DIFF
--- a/packages/lisk-transactions/src/6_in_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/6_in_transfer_transaction.ts
@@ -85,7 +85,9 @@ export class InTransferTransaction extends BaseTransaction {
 				: undefined;
 
 		if (dappTransaction) {
-			await store.account.cache([{ id: dappTransaction.senderId as string }]);
+			await store.account.cache([
+				{ address: dappTransaction.senderId as string },
+			]);
 		}
 	}
 


### PR DESCRIPTION
### What was the problem?
The filter provided for fetching dapp creator was invalid.
### How did I fix it?
Fixed the property name used in the filter.
### How to test it?
Run the tests.
### Review checklist

* The PR resolves #1223 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
