### PR TITLE
fix dappId constraint

### DIFF
--- a/packages/lisk-transactions/src/7_out_transfer_transaction.ts
+++ b/packages/lisk-transactions/src/7_out_transfer_transaction.ts
@@ -25,6 +25,7 @@ import { verifyAmountBalance } from './utils';
 import { validator } from './utils/validation';
 
 const TRANSACTION_OUTTRANSFER_TYPE = 7;
+const TRANSACTION_DAPP_REGISTERATION_TYPE = 5;
 
 export interface OutTransferAsset {
 	readonly outTransfer: {
@@ -183,11 +184,15 @@ export class OutTransferTransaction extends BaseTransaction {
 			this.asset.outTransfer.dappId,
 		);
 
-		if (dappRegistrationTransaction.senderId !== this.senderId) {
+		if (
+			!dappRegistrationTransaction ||
+			dappRegistrationTransaction.type !== TRANSACTION_DAPP_REGISTERATION_TYPE
+		) {
 			errors.push(
 				new TransactionError(
-					`Out transaction must be sent from owner of the Dapp.`,
+					`Application not found: ${this.asset.outTransfer.dappId}`,
 					this.id,
+					'.asset.outTransfer.dappId',
 				),
 			);
 		}

--- a/packages/lisk-transactions/test/7_out_transfer_transaction.ts
+++ b/packages/lisk-transactions/test/7_out_transfer_transaction.ts
@@ -18,6 +18,7 @@ import { MockStateStore as store } from './helpers';
 import { OutTransferTransaction } from '../src/7_out_transfer_transaction';
 import {
 	validOutTransferTransactions,
+	validTransaction,
 	validDappTransactions,
 } from '../fixtures';
 import { TransactionJSON } from '../src/transaction_types';
@@ -275,14 +276,22 @@ describe('outTransfer transaction class', () => {
 			);
 		});
 
-		it('should return error when not sent from owner of dapp', async () => {
+		it('should return error when transaction is not a dapp', async () => {
 			const invalidTestTransaction = new OutTransferTransaction({
 				...defaultTransaction,
-				senderId: '123L',
+				asset: {
+					outTransfer: {
+						dappId: '123',
+					},
+				},
 			});
+			storeTransactionGetStub.returns(validTransaction);
+
 			const errors = (invalidTestTransaction as any).applyAsset(store);
 			expect(errors[0].message).to.equal(
-				`Out transaction must be sent from owner of the Dapp.`,
+				`Application not found: ${
+					invalidTestTransaction.asset.outTransfer.dappId
+				}`,
 			);
 		});
 


### PR DESCRIPTION
### What was the problem?
OutTransfer transaction implementation checks whether dappId creator is the creator of the outtransfer transaction, which is not the current behaviour of lisk-core and it fails when syncing with testnet.
### How did I fix it?
For OutTransfer transaction, the transaction which is specified in the dappId should be a dapp registeration transaction, irrespective of whether the sender of out transfer transaction is the creator of the transaction specified in the dappID.
### How to test it?
Sync against testnet.
### Review checklist

* The PR resolves #INSERT_ISSUE_NUMBER
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
