### PR TITLE
Multi-signature registration - Create member accounts - Closes #1227

### DIFF
--- a/packages/lisk-transactions/src/4_multisignature_transaction.ts
+++ b/packages/lisk-transactions/src/4_multisignature_transaction.ts
@@ -123,20 +123,16 @@ export class MultisignatureTransaction extends BaseTransaction {
 	}
 
 	public async prepare(store: StateStorePrepare): Promise<void> {
+		const membersAddresses = extractPublicKeysFromAsset(
+			this.asset.multisignature.keysgroup,
+		).map(publicKey => ({ address: getAddressFromPublicKey(publicKey) }));
+
 		await store.account.cache([
 			{
 				address: this.senderId,
 			},
+			...membersAddresses,
 		]);
-
-		const membersPubilckeys = extractPublicKeysFromAsset(
-			this.asset.multisignature.keysgroup,
-		);
-		const memberPromises = membersPubilckeys.map(async publicKey =>
-			store.account.cache([{ address: getAddressFromPublicKey(publicKey) }]),
-		);
-
-		await Promise.all(memberPromises);
 	}
 
 	protected verifyAgainstTransactions(


### PR DESCRIPTION
### What was the problem?

Group member accounts were not being created when registering a multi-signature transaction

### How did I fix it?

By adding methods to fetch/create the group member accounts

### How to test it?

- Build should be green
- Register a multi-signature with two members and the two members should have accounts created
- Credit two accounts, register multi-signature for the first one and use the second one and another one as members. Registration should succeed and second account should have same balance

### Review checklist

* The PR resolves #1227
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
