### PR TITLE
The P2PPeerSelectionForSendRequest function should receive the current message/request packet as an argument - Closes #1200

### DIFF
--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -50,13 +50,13 @@ import {
 	P2PNetworkStatus,
 	P2PNodeInfo,
 	P2PPeerInfo,
+	P2PPeerSelectionForRequest,
+	P2PPeerSelectionForSend,
 	P2PPenalty,
 	P2PRequestPacket,
 	P2PResponsePacket,
 	ProtocolPeerInfo,
 	ProtocolPeerInfoList,
-	P2PPeerSelectionForSend,
-	P2PPeerSelectionForRequest,
 } from './p2p_types';
 
 import { P2PRequest } from './p2p_request';
@@ -236,10 +236,10 @@ export class P2P extends EventEmitter {
 			ackTimeout: config.ackTimeout,
 			peerSelectionForSend: config.peerSelectionForSend
 				? config.peerSelectionForSend
-				: selectPeers as P2PPeerSelectionForSend,
+				: (selectPeers as P2PPeerSelectionForSend),
 			peerSelectionForRequest: config.peerSelectionForRequest
 				? config.peerSelectionForRequest
-				: selectPeers as P2PPeerSelectionForRequest,
+				: (selectPeers as P2PPeerSelectionForRequest),
 			peerSelectionForConnection: config.peerSelectionForConnection
 				? config.peerSelectionForConnection
 				: selectForConnection,

--- a/packages/lisk-p2p/src/p2p.ts
+++ b/packages/lisk-p2p/src/p2p.ts
@@ -55,6 +55,8 @@ import {
 	P2PResponsePacket,
 	ProtocolPeerInfo,
 	ProtocolPeerInfoList,
+	P2PPeerSelectionForSend,
+	P2PPeerSelectionForRequest,
 } from './p2p_types';
 
 import { P2PRequest } from './p2p_request';
@@ -230,11 +232,14 @@ export class P2P extends EventEmitter {
 		};
 
 		this._peerPool = new PeerPool({
-			connectTimeout: this._config.connectTimeout,
-			ackTimeout: this._config.ackTimeout,
-			peerSelectionForSendRequest: config.peerSelectionForSendRequest
-				? config.peerSelectionForSendRequest
-				: selectPeers,
+			connectTimeout: config.connectTimeout,
+			ackTimeout: config.ackTimeout,
+			peerSelectionForSend: config.peerSelectionForSend
+				? config.peerSelectionForSend
+				: selectPeers as P2PPeerSelectionForSend,
+			peerSelectionForRequest: config.peerSelectionForRequest
+				? config.peerSelectionForRequest
+				: selectPeers as P2PPeerSelectionForRequest,
 			peerSelectionForConnection: config.peerSelectionForConnection
 				? config.peerSelectionForConnection
 				: selectForConnection,

--- a/packages/lisk-p2p/src/p2p_types.ts
+++ b/packages/lisk-p2p/src/p2p_types.ts
@@ -14,16 +14,20 @@
  */
 /* tslint:disable:no-empty-interface*/
 
-export interface P2PRequestPacket {
+export interface P2PPacket {
+	readonly data?: unknown;
+}
+
+export interface P2PRequestPacket extends P2PPacket {
 	readonly data?: unknown;
 	readonly procedure: string;
 }
 
-export interface P2PResponsePacket {
+export interface P2PResponsePacket extends P2PPacket {
 	readonly data: unknown;
 }
 
-export interface P2PMessagePacket {
+export interface P2PMessagePacket extends P2PPacket {
 	readonly data?: unknown;
 	readonly event: string;
 }
@@ -76,7 +80,8 @@ export interface P2PConfig {
 	readonly nodeInfo: P2PNodeInfo;
 	readonly wsEngine?: string;
 	readonly discoveryInterval?: number;
-	readonly peerSelectionForSendRequest?: P2PPeerSelectionForSendRequest;
+	readonly peerSelectionForSend?: P2PPeerSelectionForSend;
+	readonly peerSelectionForRequest?: P2PPeerSelectionForRequest;
 	readonly peerSelectionForConnection?: P2PPeerSelectionForConnection;
 	readonly peerHandshakeCheck?: P2PCheckPeerCompatibility;
 }
@@ -107,6 +112,20 @@ export type P2PPeerSelectionForSendRequest = (
 	peers: ReadonlyArray<P2PDiscoveredPeerInfo>,
 	nodeInfo?: P2PNodeInfo,
 	numOfPeers?: number,
+) => ReadonlyArray<P2PDiscoveredPeerInfo>;
+
+export type P2PPeerSelectionForSend = (
+	peers: ReadonlyArray<P2PDiscoveredPeerInfo>,
+	nodeInfo?: P2PNodeInfo,
+	numOfPeers?: number,
+	messagePacket?: P2PMessagePacket
+) => ReadonlyArray<P2PDiscoveredPeerInfo>;
+
+export type P2PPeerSelectionForRequest = (
+	peers: ReadonlyArray<P2PDiscoveredPeerInfo>,
+	nodeInfo?: P2PNodeInfo,
+	numOfPeers?: number,
+	requestPacket?: P2PRequestPacket
 ) => ReadonlyArray<P2PDiscoveredPeerInfo>;
 
 export type P2PPeerSelectionForConnection = (

--- a/packages/lisk-p2p/src/peer_pool.ts
+++ b/packages/lisk-p2p/src/peer_pool.ts
@@ -32,8 +32,8 @@ import {
 	P2PNodeInfo,
 	P2PPeerInfo,
 	P2PPeerSelectionForConnection,
-	P2PPeerSelectionForSend,
 	P2PPeerSelectionForRequest,
+	P2PPeerSelectionForSend,
 	P2PRequestPacket,
 	P2PResponsePacket,
 } from './p2p_types';

--- a/packages/lisk-p2p/test/integration/p2p.ts
+++ b/packages/lisk-p2p/test/integration/p2p.ts
@@ -4,6 +4,8 @@ import { wait } from '../utils/helpers';
 import { platform } from 'os';
 import {
 	P2PPeerSelectionForSendRequest,
+	P2PPeerSelectionForSend,
+	P2PPeerSelectionForRequest,
 	P2PNodeInfo,
 	P2PDiscoveredPeerInfo,
 	P2PPeerSelectionForConnection,
@@ -745,7 +747,8 @@ describe('Integration tests for P2P library', () => {
 					blacklistedPeers: [],
 					connectTimeout: 5000,
 					ackTimeout: 5000,
-					peerSelectionForSendRequest,
+					peerSelectionForSend: peerSelectionForSendRequest as P2PPeerSelectionForSend,
+					peerSelectionForRequest: peerSelectionForSendRequest as P2PPeerSelectionForRequest,
 					peerSelectionForConnection,
 					seedPeers,
 					wsEngine: 'ws',


### PR DESCRIPTION
### What was the problem?

- There was no way to specify the peer selection request separately for send vs request actions.
- The peer selection functions should accept the request or message as an argument so that they can use it for routing (subnet feature).

### How did I fix it?

- Separated the peer selection functions.
- Pass the message or request as argument to those functions.

### How to test it?

`npm run test`

### Review checklist

* The PR resolves #1200 
* All new code is covered with unit tests
* All new code was formatted with Prettier
* Linting passes
* Tests pass
* Commit messages follow the [commit guidelines](CONTRIBUTING.md#git-commit-messages)
* Documentation has been added/updated
